### PR TITLE
OCD-1015: Add numMeaningfulUse to CertifiedProductSearchDetails and CertifiedProductSearchResult

### DIFF
--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/domain/CertifiedProductSearchDetails.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/domain/CertifiedProductSearchDetails.java
@@ -40,6 +40,7 @@ public class CertifiedProductSearchDetails {
 	private String transparencyAttestation;
 	private String transparencyAttestationUrl;
 	private Long lastModifiedDate;
+	private Long numMeaningfulUse;
 	
 	private List<CertifiedProductAccessibilityStandard> accessibilityStandards = new ArrayList<CertifiedProductAccessibilityStandard>();
 	private List<CertifiedProductTargetedUser> targetedUsers = new ArrayList<CertifiedProductTargetedUser>();
@@ -282,5 +283,11 @@ public class CertifiedProductSearchDetails {
 	}
 	public void setSurveillance(List<Surveillance> surveillance) {
 		this.surveillance = surveillance;
+	}
+	public Long getNumMeaningfulUse() {
+		return numMeaningfulUse;
+	}
+	public void setNumMeaningfulUse(Long numMeaningfulUse) {
+		this.numMeaningfulUse = numMeaningfulUse;
 	}
 }

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/domain/CertifiedProductSearchResult.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/domain/CertifiedProductSearchResult.java
@@ -37,6 +37,7 @@ public class CertifiedProductSearchResult {
 	private Integer countCorrectiveActionPlans;
 	private Integer countCurrentCorrectiveActionPlans;
 	private Integer countClosedCorrectiveActionPlans;
+	private Long numMeaningfulUse;
 	
 	public Long getId() {
 		return id;
@@ -217,6 +218,12 @@ public class CertifiedProductSearchResult {
 	}
 	public void setSedTestingEnd(Date sedTestingEnd) {
 		this.sedTestingEnd = sedTestingEnd;
+	}
+	public Long getNumMeaningfulUse() {
+		return numMeaningfulUse;
+	}
+	public void setNumMeaningfulUse(Long numMeaningfulUse) {
+		this.numMeaningfulUse = numMeaningfulUse;
 	}
 	
 }

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/dto/CertifiedProductDetailsDTO.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/dto/CertifiedProductDetailsDTO.java
@@ -55,6 +55,7 @@ public class CertifiedProductDetailsDTO {
 	private String productAdditionalSoftware;
 	private String transparencyAttestation;
 	private String transparencyAttestationUrl;
+	private Long numMeaningfulUse;
 	
 	private List<CertifiedProductQmsStandardDTO> qmsStandards;
 	private List<TargetedUserDTO> targetedUsers;
@@ -98,6 +99,7 @@ public class CertifiedProductDetailsDTO {
     	this.sedTestingEnd = entity.getSedTestingEnd();
     	this.testingLabId = entity.getTestingLabId();
     	this.testingLabName = entity.getTestingLabName();
+    	this.numMeaningfulUse = entity.getMeaningfulUseUsers();
     	
 		this.developer = new DeveloperDTO();
     	this.developer.setId(entity.getDeveloperId());
@@ -525,5 +527,13 @@ public class CertifiedProductDetailsDTO {
 
 	public void setVersion(ProductVersionDTO version) {
 		this.version = version;
+	}
+
+	public Long getNumMeaningfulUse() {
+		return numMeaningfulUse;
+	}
+
+	public void setNumMeaningfulUse(Long numMeaningfulUse) {
+		this.numMeaningfulUse = numMeaningfulUse;
 	}
 }

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/CertifiedProductDetailsManagerImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/CertifiedProductDetailsManagerImpl.java
@@ -186,6 +186,8 @@ public class CertifiedProductDetailsManagerImpl implements CertifiedProductDetai
 		searchDetails.setCountCorrectiveActionPlans(dto.getCountCorrectiveActionPlans());
 		searchDetails.setCountCurrentCorrectiveActionPlans(dto.getCountCurrentCorrectiveActionPlans());
 		searchDetails.setCountClosedCorrectiveActionPlans(dto.getCountClosedCorrectiveActionPlans());
+		searchDetails.setNumMeaningfulUse(dto.getNumMeaningfulUse());
+		
 		
 		List<Surveillance> cpSurveillance = survManager.getByCertifiedProduct(dto.getId());
 		searchDetails.setSurveillance(cpSurveillance);

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/CertifiedProductSearchManagerImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/CertifiedProductSearchManagerImpl.java
@@ -94,6 +94,7 @@ public class CertifiedProductSearchManagerImpl implements CertifiedProductSearch
 			searchResult.setProductAdditionalSoftware(dto.getProductAdditionalSoftware());
 			searchResult.setTransparencyAttestation(dto.getTransparencyAttestation());
 			searchResult.setTransparencyAttestationUrl(dto.getTransparencyAttestationUrl());
+			searchResult.setNumMeaningfulUse(dto.getNumMeaningfulUse());
 			
 			searchResults.add(searchResult);
 		}

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/web/controller/SearchViewControllerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/web/controller/SearchViewControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
@@ -27,6 +28,8 @@ import gov.healthit.chpl.auth.permission.GrantedPermission;
 import gov.healthit.chpl.auth.user.JWTAuthenticatedUser;
 import gov.healthit.chpl.dao.EntityCreationException;
 import gov.healthit.chpl.dao.EntityRetrievalException;
+import gov.healthit.chpl.domain.CertifiedProductSearchDetails;
+import gov.healthit.chpl.domain.CertifiedProductSearchResult;
 import gov.healthit.chpl.domain.DeveloperDecertificationResponse;
 import gov.healthit.chpl.domain.PopulateSearchOptions;
 import gov.healthit.chpl.domain.SearchRequest;
@@ -63,8 +66,7 @@ public class SearchViewControllerTest {
 	 * 
 	 * Expected Result: Completes without error and returns some SearchResponse records
 	 */
-	@Transactional
-	@Rollback(true) 
+	@Transactional 
 	@Test
 	public void test_advancedSearch_refineByCqms_CompletesWithoutError() throws EntityRetrievalException, JsonProcessingException, EntityCreationException{
 		SecurityContextHolder.getContext().setAuthentication(adminUser);
@@ -87,7 +89,6 @@ public class SearchViewControllerTest {
 	 * Expected Result: Completes without error and returns some SearchResponse records
 	 */
 	@Transactional
-	@Rollback(true)
 	@Test
 	public void test_advancedSearch_refineByCertificationCriteria_CompletesWithoutError() throws EntityRetrievalException, JsonProcessingException, EntityCreationException{
 		SecurityContextHolder.getContext().setAuthentication(adminUser);
@@ -111,7 +112,6 @@ public class SearchViewControllerTest {
 	 * Expected Result: Completes without error and returns some SearchResponse records
 	 */
 	@Transactional
-	@Rollback(true)
 	@Test
 	public void test_advancedSearch_refineByCertificationCriteriaAndCqms_CompletesWithoutError() throws EntityRetrievalException, JsonProcessingException, EntityCreationException{
 		SecurityContextHolder.getContext().setAuthentication(adminUser);
@@ -140,7 +140,6 @@ public class SearchViewControllerTest {
 	 * Pre-existing data in openchpl_test DB is there per the \CHPL\chpl-api\chpl\chpl-service\src\test\resources\data\testData.xml
 	 */
 	@Transactional
-	@Rollback(true)
 	@Test
 	public void test_getPopulateSearchData_simpleAsTrue_Caching_CompletesWithoutError() throws EntityRetrievalException, JsonProcessingException, EntityCreationException{
 		SecurityContextHolder.getContext().setAuthentication(adminUser);
@@ -180,7 +179,6 @@ public class SearchViewControllerTest {
 	 * Then the controller method's getDeveloperDecertifications returns expected results
 	 */
 	@Transactional
-	@Rollback(true)
 	@Test
 	public void test_getDeveloperDecertifications_CompletesWithoutError() throws EntityRetrievalException, JsonProcessingException, EntityCreationException{
 		DeveloperDecertificationResponse resp = searchViewController.getDeveloperDecertifications();
@@ -188,4 +186,74 @@ public class SearchViewControllerTest {
 				resp.getDeveloperDecertificationResult().size() == 2);
 	}
 	
+	/** 
+	 * Given the CHPL is accepting search requests
+	 * When I call the REST API's /
+	 * Then the controller method's advancedSearch returns SearchResponse containing numMeaningfulUse
+	 */
+	@Transactional
+	@Test
+	public void test_advancedSearch_resultReturnsNumMeaningfulUse() {
+		SearchRequest sr = new SearchRequest();
+		sr.setPageNumber(0);
+		sr.setPageSize(50);
+		sr.setOrderBy("developer");
+		sr.setSortDescending(true);
+		sr.setDeveloper("VendorSuspended");
+		
+		SearchResponse resp = searchViewController.advancedSearch(sr);
+		assertTrue("SearchResponse should have size > 0 but is " + resp.getResults().size(), resp.getResults().size() > 0);
+		Boolean hasNumMeaningfulUse = false;
+		for(CertifiedProductSearchResult result : resp.getResults()){
+			if(result.getNumMeaningfulUse() != null){
+				hasNumMeaningfulUse = true;
+				break;
+			}
+		}
+		assertTrue("SearchResponse should contain results with numMeaningfulUse.", hasNumMeaningfulUse);
+	}
+	
+	/** 
+	 * Given the CHPL is accepting search requests
+	 * When I call the REST API's /
+	 * Then the controller method's advancedSearch returns SearchResponse containing numMeaningfulUse
+	 * @throws EntityRetrievalException 
+	 */
+	@Transactional
+	@Test
+	public void test_simpleSearch_resultReturnsNumMeaningfulUse() throws EntityRetrievalException {
+		String searchTerm = "VendorSuspended";
+		Integer pageNumber = 0;
+		Integer pageSize = 50;
+		String orderBy = "developer";
+		Boolean sortDescending = true;
+		
+		SearchResponse resp = searchViewController.simpleSearch(searchTerm, pageNumber, pageSize, orderBy, sortDescending);
+		assertTrue("SearchResponse should have size > 0 but is " + resp.getResults().size(), resp.getResults().size() > 0);
+		Boolean hasNumMeaningfulUse = false;
+		for(CertifiedProductSearchResult result : resp.getResults()){
+			if(result.getNumMeaningfulUse() != null){
+				hasNumMeaningfulUse = true;
+				break;
+			}
+		}
+	assertTrue("SearchResponse should contain results with numMeaningfulUse.", hasNumMeaningfulUse);
+	}
+	
+	/** 
+	 * Given the CHPL is accepting search requests
+	 * When I call the REST API's /
+	 * Then the controller method's getCertifiedProductDetails returns CertifiedProductSearchDetails containing numMeaningfulUse
+	 * @throws EntityRetrievalException 
+	 */
+	@Transactional
+	@Test
+	public void test_getCertifiedProductDetails_resultReturnsNumMeaningfulUse() throws EntityRetrievalException {
+		Long cpId = 6L;
+		
+		CertifiedProductSearchDetails resp = searchViewController.getCertifiedProductDetails(cpId);
+		assertTrue("Response should contain results but is null", resp != null);
+		assertTrue("Response should contain certified product with numMeaningfulUse == 12 but contains numMeaningfulUse of " + resp.getNumMeaningfulUse(),
+				resp.getNumMeaningfulUse() == 12);
+	}
 }


### PR DESCRIPTION
Provides numMeaningfulUse in the following API calls:
* SearchViewController.simpleSearch
* SearchViewController.advancedSearch
* SearchViewController.getCertifiedProductDetails