### PR TITLE
OCD-1208: Remove cache for pending; evict all cache entries; refactors

### DIFF
--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/caching/AsynchronousCacheInitialization.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/caching/AsynchronousCacheInitialization.java
@@ -1,7 +1,6 @@
 package gov.healthit.chpl.caching;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.Future;
 
 import org.apache.logging.log4j.LogManager;
@@ -13,9 +12,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import gov.healthit.chpl.dao.EntityRetrievalException;
-import gov.healthit.chpl.dto.PendingCertifiedProductDTO;
 import gov.healthit.chpl.manager.CertificationIdManager;
-import gov.healthit.chpl.manager.PendingCertifiedProductManager;
 import gov.healthit.chpl.manager.SearchMenuManager;
 
 @Component
@@ -24,7 +21,6 @@ public class AsynchronousCacheInitialization {
 	
 	@Autowired private CertificationIdManager certificationIdManager;
 	@Autowired private SearchMenuManager searchMenuManager;
-	@Autowired private PendingCertifiedProductManager pcpManager;
 	
 	@Async
 	@Transactional
@@ -43,16 +39,6 @@ public class AsynchronousCacheInitialization {
 		searchMenuManager.getCertificationCriterionNumbers(false);
 		searchMenuManager.getCertificationCriterionNumbers(true);
 		logger.info("Finished cache initialization for SearchViewController.getPopulateSearchData()");
-		return new AsyncResult<>(true);
-	}
-	
-	@Async
-	@Transactional
-	public Future<Boolean> initializePending() throws EntityRetrievalException{
-		logger.info("Starting cache initialization for /pending");
-		List<PendingCertifiedProductDTO> pendingResults = pcpManager.getPending();
-		pcpManager.getPendingCertifiedProductResults(pendingResults);
-		logger.info("Finished cache initialization for /pending");
 		return new AsyncResult<>(true);
 	}
 	

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/caching/AsynchronousCacheInitialization.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/caching/AsynchronousCacheInitialization.java
@@ -1,6 +1,7 @@
 package gov.healthit.chpl.caching;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.Future;
 
 import org.apache.logging.log4j.LogManager;
@@ -11,11 +12,10 @@ import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import gov.healthit.chpl.dao.CertificationStatusDAO;
 import gov.healthit.chpl.dao.EntityRetrievalException;
-import gov.healthit.chpl.dao.PendingCertifiedProductDAO;
-import gov.healthit.chpl.dto.CertificationStatusDTO;
+import gov.healthit.chpl.dto.PendingCertifiedProductDTO;
 import gov.healthit.chpl.manager.CertificationIdManager;
+import gov.healthit.chpl.manager.PendingCertifiedProductManager;
 import gov.healthit.chpl.manager.SearchMenuManager;
 
 @Component
@@ -24,8 +24,7 @@ public class AsynchronousCacheInitialization {
 	
 	@Autowired private CertificationIdManager certificationIdManager;
 	@Autowired private SearchMenuManager searchMenuManager;
-	@Autowired private PendingCertifiedProductDAO pcpDao;
-	@Autowired private CertificationStatusDAO statusDao;
+	@Autowired private PendingCertifiedProductManager pcpManager;
 	
 	@Async
 	@Transactional
@@ -51,8 +50,8 @@ public class AsynchronousCacheInitialization {
 	@Transactional
 	public Future<Boolean> initializePending() throws EntityRetrievalException{
 		logger.info("Starting cache initialization for /pending");
-		CertificationStatusDTO statusDto = statusDao.getByStatusName("Pending");
-		pcpDao.findByStatus(statusDto.getId());
+		List<PendingCertifiedProductDTO> pendingResults = pcpManager.getPending();
+		pcpManager.getPendingCertifiedProductResults(pendingResults);
 		logger.info("Finished cache initialization for /pending");
 		return new AsyncResult<>(true);
 	}

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/caching/CacheInitializor.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/caching/CacheInitializor.java
@@ -33,7 +33,6 @@ public class CacheInitializor {
 	private Long tClearAllStart;
 	private Long tClearAllEnd;
 	private Double tClearAllElapsedSecs;
-	private Future<Boolean> isInitializePendingDone;
 	private Future<Boolean> isInitializeSearchOptionsDone;
 	private Future<Boolean> isInitializeCertificationIdsGetAllDone;
 	private Future<Boolean> isInitializeCertificationIdsGetAllWithProductsDone;
@@ -78,11 +77,6 @@ public class CacheInitializor {
 					}
 					isInitializeSearchOptionsDone = asynchronousCacheInitialization.initializeSearchOptions();
 					
-					if(isInitializePendingDone != null && !isInitializePendingDone.isDone()){
-						isInitializePendingDone.cancel(true);	
-					}
-					isInitializePendingDone = asynchronousCacheInitialization.initializePending();
-					
 					if(isInitializeCertificationIdsGetAllDone != null && !isInitializeCertificationIdsGetAllDone.isDone()){
 						isInitializeCertificationIdsGetAllDone.cancel(true);
 					}
@@ -117,10 +111,6 @@ public class CacheInitializor {
 			// Stop initializing caches if running
 			if(isInitializeSearchOptionsDone != null && !isInitializeSearchOptionsDone.isDone()){
 				isInitializeSearchOptionsDone.cancel(true);
-			}
-			
-			if(isInitializePendingDone != null && !isInitializePendingDone.isDone()){
-				isInitializePendingDone.cancel(true);	
 			}
 			
 			if(isInitializeCertificationIdsGetAllDone != null && !isInitializeCertificationIdsGetAllDone.isDone()){

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/caching/CacheNames.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/caching/CacheNames.java
@@ -15,8 +15,6 @@ public class CacheNames {
 	public static final String MACRA_MEASURES = "macrameasures";
 	public static final String CQM_CRITERION_NUMBERS = "cqmCriterionNumbers";
 	public static final String CERTIFICATION_CRITERION_NUMBERS = "certificationCriterionNumbers";
-	public static final String GET_PENDING = "getPending";
-	public static final String GET_PENDING_CERTIFIED_PRODUCT_RESULTS = "getPendingCertifiedProductResults";
 	public static final String SEARCH = "search";
 	public static final String COUNT_MULTI_FILTER_SEARCH_RESULTS = "countMultiFilterSearchResults";
 	public static final String GET_DECERTIFIED_DEVELOPERS = "getDecertifiedDevelopers";

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/caching/CacheNames.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/caching/CacheNames.java
@@ -1,23 +1,23 @@
 package gov.healthit.chpl.caching;
 
 public class CacheNames {
-	public static final String allCertIdsWithProducts = "allCertIdsWithProducts";
-	public static final String allCertIds = "allCertIds";
-	public static final String allDevelopers = "allDevelopers";
-	public static final String allDevelopersIncludingDeleted = "allDevelopersIncludingDeleted";
-	public static final String certBodyNames = "certBodyNames";
-	public static final String editionNames = "editionNames";
-	public static final String certificationStatuses = "certificationStatuses";
-	public static final String practiceTypeNames = "practiceTypeNames";
-	public static final String classificationNames = "classificationNames";
-	public static final String productNames = "productNames";
-	public static final String developerNames = "developerNames";
-	public static final String macrameasures = "macrameasures";
-	public static final String cqmCriterionNumbers = "cqmCriterionNumbers";
-	public static final String certificationCriterionNumbers = "certificationCriterionNumbers";
-	public static final String getByStatusName = "getByStatusName";
-	public static final String findByStatus = "findByStatus";
-	public static final String search = "search";
-	public static final String countMultiFilterSearchResults = "countMultiFilterSearchResults";
-	public static final String getDecertifiedDevelopers = "getDecertifiedDevelopers";
+	public static final String ALL_CERT_IDS_WITH_PRODUCTS = "allCertIdsWithProducts";
+	public static final String ALL_CERT_IDS = "allCertIds";
+	public static final String ALL_DEVELOPERS = "allDevelopers";
+	public static final String ALL_DEVELOPERS_INCLUDING_DELETED = "allDevelopersIncludingDeleted";
+	public static final String CERT_BODY_NAMES = "certBodyNames";
+	public static final String EDITION_NAMES = "editionNames";
+	public static final String CERTIFICATION_STATUSES = "certificationStatuses";
+	public static final String PRACTICE_TYPE_NAMES = "practiceTypeNames";
+	public static final String CLASSIFICATION_NAMES = "classificationNames";
+	public static final String PRODUCT_NAMES = "productNames";
+	public static final String DEVELOPER_NAMES = "developerNames";
+	public static final String MACRA_MEASURES = "macrameasures";
+	public static final String CQM_CRITERION_NUMBERS = "cqmCriterionNumbers";
+	public static final String CERTIFICATION_CRITERION_NUMBERS = "certificationCriterionNumbers";
+	public static final String GET_PENDING = "getPending";
+	public static final String GET_PENDING_CERTIFIED_PRODUCT_RESULTS = "getPendingCertifiedProductResults";
+	public static final String SEARCH = "search";
+	public static final String COUNT_MULTI_FILTER_SEARCH_RESULTS = "countMultiFilterSearchResults";
+	public static final String GET_DECERTIFIED_DEVELOPERS = "getDecertifiedDevelopers";
 }

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/dao/impl/CertificationStatusDAOImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/dao/impl/CertificationStatusDAOImpl.java
@@ -39,7 +39,6 @@ public class CertificationStatusDAOImpl extends BaseDAOImpl implements Certifica
 	}
 
 	@Override
-	@Cacheable(CacheNames.getByStatusName)
 	public CertificationStatusDTO getByStatusName(String statusName) {
 		CertificationStatusEntity entity = getEntityByName(statusName);
 		return new CertificationStatusDTO(entity);

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/dao/impl/CertificationStatusDAOImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/dao/impl/CertificationStatusDAOImpl.java
@@ -5,10 +5,8 @@ import java.util.List;
 
 import javax.persistence.Query;
 
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 
-import gov.healthit.chpl.caching.CacheNames;
 import gov.healthit.chpl.dao.CertificationStatusDAO;
 import gov.healthit.chpl.dao.EntityRetrievalException;
 import gov.healthit.chpl.dto.CertificationStatusDTO;

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/dao/impl/CertifiedProductSearchResultDAOImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/dao/impl/CertifiedProductSearchResultDAOImpl.java
@@ -395,7 +395,7 @@ public class CertifiedProductSearchResultDAOImpl extends BaseDAOImpl implements
 
 	@Override
 	@Transactional
-	@Cacheable(CacheNames.countMultiFilterSearchResults)
+	@Cacheable(CacheNames.COUNT_MULTI_FILTER_SEARCH_RESULTS)
 	public Long countMultiFilterSearchResults(SearchRequest searchRequest) {
 		
 		Query query = getCountQueryForSearchFilters(searchRequest);

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/dao/impl/PendingCertifiedProductDAOImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/dao/impl/PendingCertifiedProductDAOImpl.java
@@ -6,12 +6,10 @@ import java.util.List;
 
 import javax.persistence.Query;
 
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import gov.healthit.chpl.auth.Util;
-import gov.healthit.chpl.caching.CacheNames;
 import gov.healthit.chpl.dao.EntityRetrievalException;
 import gov.healthit.chpl.dao.PendingCertifiedProductDAO;
 import gov.healthit.chpl.dto.CertificationStatusDTO;
@@ -295,7 +293,6 @@ public class PendingCertifiedProductDAOImpl extends BaseDAOImpl implements Pendi
 		return dtos;
 	}
 	
-	@Cacheable(CacheNames.findByStatus)
 	@Transactional
 	public List<PendingCertifiedProductDTO> findByStatus(Long statusId) {
 		List<PendingCertifiedProductEntity> entities = getEntitiesByStatus(statusId);

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/PendingCertifiedProductManager.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/PendingCertifiedProductManager.java
@@ -17,6 +17,7 @@ import gov.healthit.chpl.domain.PendingCertifiedProductDetails;
 import gov.healthit.chpl.dto.CertificationBodyDTO;
 import gov.healthit.chpl.dto.PendingCertifiedProductDTO;
 import gov.healthit.chpl.entity.PendingCertifiedProductEntity;
+import gov.healthit.chpl.web.controller.results.PendingCertifiedProductResults;
 
 
 public interface PendingCertifiedProductManager {
@@ -24,6 +25,7 @@ public interface PendingCertifiedProductManager {
 	public List<PendingCertifiedProductDTO> getByAcb(CertificationBodyDTO acb);
 	public List<PendingCertifiedProductDetails> getDetailsByAcb(CertificationBodyDTO acb);
 	public List<PendingCertifiedProductDTO> getPending();
+	public PendingCertifiedProductResults getPendingCertifiedProductResults(List<PendingCertifiedProductDTO> products);
 	public List<CQMCriterion> getApplicableCriteria(PendingCertifiedProductDTO pendingCpDto);
 	
 	public PendingCertifiedProductDTO createOrReplace(Long acbId, PendingCertifiedProductEntity toCreate) 

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/PendingCertifiedProductManager.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/PendingCertifiedProductManager.java
@@ -17,7 +17,6 @@ import gov.healthit.chpl.domain.PendingCertifiedProductDetails;
 import gov.healthit.chpl.dto.CertificationBodyDTO;
 import gov.healthit.chpl.dto.PendingCertifiedProductDTO;
 import gov.healthit.chpl.entity.PendingCertifiedProductEntity;
-import gov.healthit.chpl.web.controller.results.PendingCertifiedProductResults;
 
 
 public interface PendingCertifiedProductManager {
@@ -25,7 +24,6 @@ public interface PendingCertifiedProductManager {
 	public List<PendingCertifiedProductDTO> getByAcb(CertificationBodyDTO acb);
 	public List<PendingCertifiedProductDetails> getDetailsByAcb(CertificationBodyDTO acb);
 	public List<PendingCertifiedProductDTO> getPending();
-	public PendingCertifiedProductResults getPendingCertifiedProductResults(List<PendingCertifiedProductDTO> products);
 	public List<CQMCriterion> getApplicableCriteria(PendingCertifiedProductDTO pendingCpDto);
 	
 	public PendingCertifiedProductDTO createOrReplace(Long acbId, PendingCertifiedProductEntity toCreate) 

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/CertificationIdManagerImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/CertificationIdManagerImpl.java
@@ -76,7 +76,7 @@ public class CertificationIdManagerImpl implements CertificationIdManager {
 	
 	@Override
 	@Transactional(readOnly = true)
-	@Cacheable(CacheNames.allCertIds)
+	@Cacheable(CacheNames.ALL_CERT_IDS)
 	/**
 	 * Should be secured at controller level for ROLE_ADMIN || ROLE_ONC_STAFF || ROLE_CMS_STAFF
 	 */
@@ -91,7 +91,7 @@ public class CertificationIdManagerImpl implements CertificationIdManager {
 
 	@Override
 	@Transactional(readOnly = true)
-	@Cacheable(CacheNames.allCertIdsWithProducts)
+	@Cacheable(CacheNames.ALL_CERT_IDS_WITH_PRODUCTS)
 	/**
 	 * Should be secured at controller level for ROLE_ADMIN || ROLE_ONC_STAFF
 	 */
@@ -126,7 +126,7 @@ public class CertificationIdManagerImpl implements CertificationIdManager {
 	
 	@Override
 	@Transactional(readOnly = false)
-	@CacheEvict(value = {CacheNames.allCertIds, CacheNames.allCertIdsWithProducts})
+	@CacheEvict(value = {CacheNames.ALL_CERT_IDS, CacheNames.ALL_CERT_IDS_WITH_PRODUCTS}, allEntries=true)
 	public CertificationIdDTO create(List<Long> productIds, String year) throws EntityRetrievalException, EntityCreationException, JsonProcessingException {
 		
 		CertificationIdDTO result = CertificationIdDAO.create(productIds, year);

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/CertifiedProductManagerImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/CertifiedProductManagerImpl.java
@@ -26,6 +26,7 @@ import gov.healthit.chpl.auth.SendMailUtil;
 import gov.healthit.chpl.auth.Util;
 import gov.healthit.chpl.caching.CacheNames;
 import gov.healthit.chpl.caching.ClearAllCaches;
+import gov.healthit.chpl.caching.ClearDecertifiedDevelopers;
 import gov.healthit.chpl.dao.AccessibilityStandardDAO;
 import gov.healthit.chpl.dao.CQMCriterionDAO;
 import gov.healthit.chpl.dao.CQMResultDAO;
@@ -289,8 +290,10 @@ public class CertifiedProductManagerImpl implements CertifiedProductManager {
 	@PreAuthorize("(hasRole('ROLE_ACB_STAFF') or hasRole('ROLE_ACB_ADMIN')) "
 			+ "and hasPermission(#acbId, 'gov.healthit.chpl.dto.CertificationBodyDTO', admin)")
 	@Transactional(readOnly = false)
-	@CacheEvict(value = {CacheNames.allDevelopers, CacheNames.allDevelopersIncludingDeleted, CacheNames.developerNames, CacheNames.productNames, CacheNames.findByStatus, 
-			CacheNames.search, CacheNames.countMultiFilterSearchResults})
+	@CacheEvict(value = {CacheNames.ALL_DEVELOPERS, CacheNames.ALL_DEVELOPERS_INCLUDING_DELETED, 
+			CacheNames.DEVELOPER_NAMES, CacheNames.PRODUCT_NAMES, CacheNames.GET_PENDING, 
+			CacheNames.GET_PENDING_CERTIFIED_PRODUCT_RESULTS,
+			CacheNames.SEARCH, CacheNames.COUNT_MULTI_FILTER_SEARCH_RESULTS}, allEntries=true)
 	public CertifiedProductDTO createFromPending(Long acbId, PendingCertifiedProductDTO pendingCp) 
 			throws EntityRetrievalException, EntityCreationException, JsonProcessingException {
 		
@@ -801,7 +804,8 @@ public class CertifiedProductManagerImpl implements CertifiedProductManager {
 			+ "  and hasPermission(#acbId, 'gov.healthit.chpl.dto.CertificationBodyDTO', admin)"
 			+ ")")
 	@Transactional(readOnly = false)
-	@CacheEvict(value = {CacheNames.allDevelopers, CacheNames.allDevelopersIncludingDeleted, CacheNames.search, CacheNames.countMultiFilterSearchResults})
+	@CacheEvict(value = {CacheNames.ALL_DEVELOPERS, CacheNames.ALL_DEVELOPERS_INCLUDING_DELETED, CacheNames.SEARCH, 
+			CacheNames.COUNT_MULTI_FILTER_SEARCH_RESULTS}, allEntries=true)
 	public CertifiedProductDTO update(Long acbId, CertifiedProductDTO dto, CertifiedProductSearchDetails updateRequest) 
 			throws AccessDeniedException, EntityRetrievalException, JsonProcessingException, EntityCreationException {		
 		//if the updated certification status was suspended by onc or terminated by onc, 
@@ -1161,7 +1165,7 @@ public class CertifiedProductManagerImpl implements CertifiedProductManager {
 	@Override
 	@PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_ONC_STAFF')")
 	@Transactional(readOnly = false)
-	@CacheEvict(value = CacheNames.getDecertifiedDevelopers)
+	@CacheEvict(value = CacheNames.GET_DECERTIFIED_DEVELOPERS, allEntries=true)
 	public MeaningfulUseUserResults updateMeaningfulUseUsers(Set<MeaningfulUseUser> meaningfulUseUserSet)
 			throws EntityCreationException, EntityRetrievalException, IOException {
 		MeaningfulUseUserResults meaningfulUseUserResults = new MeaningfulUseUserResults();

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/CertifiedProductManagerImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/CertifiedProductManagerImpl.java
@@ -26,7 +26,6 @@ import gov.healthit.chpl.auth.SendMailUtil;
 import gov.healthit.chpl.auth.Util;
 import gov.healthit.chpl.caching.CacheNames;
 import gov.healthit.chpl.caching.ClearAllCaches;
-import gov.healthit.chpl.caching.ClearDecertifiedDevelopers;
 import gov.healthit.chpl.dao.AccessibilityStandardDAO;
 import gov.healthit.chpl.dao.CQMCriterionDAO;
 import gov.healthit.chpl.dao.CQMResultDAO;
@@ -291,9 +290,8 @@ public class CertifiedProductManagerImpl implements CertifiedProductManager {
 			+ "and hasPermission(#acbId, 'gov.healthit.chpl.dto.CertificationBodyDTO', admin)")
 	@Transactional(readOnly = false)
 	@CacheEvict(value = {CacheNames.ALL_DEVELOPERS, CacheNames.ALL_DEVELOPERS_INCLUDING_DELETED, 
-			CacheNames.DEVELOPER_NAMES, CacheNames.PRODUCT_NAMES, CacheNames.GET_PENDING, 
-			CacheNames.GET_PENDING_CERTIFIED_PRODUCT_RESULTS,
-			CacheNames.SEARCH, CacheNames.COUNT_MULTI_FILTER_SEARCH_RESULTS}, allEntries=true)
+			CacheNames.DEVELOPER_NAMES, CacheNames.PRODUCT_NAMES, CacheNames.SEARCH, 
+			CacheNames.COUNT_MULTI_FILTER_SEARCH_RESULTS}, allEntries=true)
 	public CertifiedProductDTO createFromPending(Long acbId, PendingCertifiedProductDTO pendingCp) 
 			throws EntityRetrievalException, EntityCreationException, JsonProcessingException {
 		

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/CertifiedProductSearchManagerImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/CertifiedProductSearchManagerImpl.java
@@ -25,7 +25,7 @@ public class CertifiedProductSearchManagerImpl implements CertifiedProductSearch
 	
 	@Transactional
 	@Override
-	@Cacheable(CacheNames.search)
+	@Cacheable(CacheNames.SEARCH)
 	public SearchResponse search(
 			SearchRequest searchRequest) {
 		

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/DeveloperManagerImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/DeveloperManagerImpl.java
@@ -61,7 +61,7 @@ public class DeveloperManagerImpl implements DeveloperManager {
 	
 	@Override
 	@Transactional(readOnly = true)
-	@Cacheable(CacheNames.allDevelopers)
+	@Cacheable(CacheNames.ALL_DEVELOPERS)
 	public List<DeveloperDTO> getAll() {
 		List<DeveloperDTO> allDevelopers = developerDao.findAll();
 		List<DeveloperDTO> allDevelopersWithTransparencies = addTransparencyMappings(allDevelopers);
@@ -71,7 +71,7 @@ public class DeveloperManagerImpl implements DeveloperManager {
 	@Override
 	@Transactional(readOnly = true)
 	@PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_ACB_ADMIN') or hasRole('ROLE_ACB_STAFF')")
-	@Cacheable(CacheNames.allDevelopersIncludingDeleted)
+	@Cacheable(CacheNames.ALL_DEVELOPERS_INCLUDING_DELETED)
 	public List<DeveloperDTO> getAllIncludingDeleted() {
 		List<DeveloperDTO> allDevelopers = developerDao.findAllIncludingDeleted();
 		List<DeveloperDTO> allDevelopersWithTransparencies = addTransparencyMappings(allDevelopers);
@@ -107,8 +107,8 @@ public class DeveloperManagerImpl implements DeveloperManager {
 
 	@PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_ACB_ADMIN') or hasRole('ROLE_ACB_STAFF')")
 	@Transactional(readOnly = false)
-	@CacheEvict(value = {CacheNames.allDevelopers, CacheNames.allDevelopersIncludingDeleted, CacheNames.developerNames, CacheNames.search, 
-			CacheNames.countMultiFilterSearchResults, CacheNames.getDecertifiedDevelopers})
+	@CacheEvict(value = {CacheNames.ALL_DEVELOPERS, CacheNames.ALL_DEVELOPERS_INCLUDING_DELETED, CacheNames.DEVELOPER_NAMES, 
+			CacheNames.SEARCH, CacheNames.COUNT_MULTI_FILTER_SEARCH_RESULTS, CacheNames.GET_DECERTIFIED_DEVELOPERS}, allEntries=true)
 	public DeveloperDTO update(DeveloperDTO developer) throws EntityRetrievalException, JsonProcessingException, EntityCreationException {
 		
 		DeveloperDTO beforeDev = getById(developer.getId());
@@ -180,8 +180,8 @@ public class DeveloperManagerImpl implements DeveloperManager {
 	
 	@PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_ACB_ADMIN') or hasRole('ROLE_ACB_STAFF')")
 	@Transactional(readOnly = false)
-	@CacheEvict(value = {CacheNames.allDevelopers, CacheNames.allDevelopersIncludingDeleted, CacheNames.developerNames, CacheNames.search, 
-			CacheNames.countMultiFilterSearchResults})
+	@CacheEvict(value = {CacheNames.ALL_DEVELOPERS, CacheNames.ALL_DEVELOPERS_INCLUDING_DELETED, CacheNames.DEVELOPER_NAMES, 
+			CacheNames.SEARCH, CacheNames.COUNT_MULTI_FILTER_SEARCH_RESULTS}, allEntries=true)
 	public DeveloperDTO create(DeveloperDTO dto) throws EntityRetrievalException, EntityCreationException, JsonProcessingException {
 		
 		DeveloperDTO created = developerDao.create(dto);
@@ -205,8 +205,8 @@ public class DeveloperManagerImpl implements DeveloperManager {
 	@Override
 	@PreAuthorize("hasRole('ROLE_ADMIN')")
 	@Transactional(readOnly = false)
-	@CacheEvict(value = {CacheNames.allDevelopers, CacheNames.allDevelopersIncludingDeleted, CacheNames.developerNames, CacheNames.search, 
-			CacheNames.countMultiFilterSearchResults, CacheNames.getDecertifiedDevelopers})
+	@CacheEvict(value = {CacheNames.ALL_DEVELOPERS, CacheNames.ALL_DEVELOPERS_INCLUDING_DELETED, CacheNames.DEVELOPER_NAMES, 
+			CacheNames.SEARCH, CacheNames.COUNT_MULTI_FILTER_SEARCH_RESULTS, CacheNames.GET_DECERTIFIED_DEVELOPERS}, allEntries=true)
 	public DeveloperDTO merge(List<Long> developerIdsToMerge, DeveloperDTO developerToCreate) throws EntityRetrievalException, JsonProcessingException, EntityCreationException {
 		
 		List<DeveloperDTO> beforeDevelopers = new ArrayList<DeveloperDTO>();
@@ -282,7 +282,7 @@ public class DeveloperManagerImpl implements DeveloperManager {
 	}
 	
 	@Transactional(readOnly = true)
-	@Cacheable(CacheNames.getDecertifiedDevelopers)
+	@Cacheable(CacheNames.GET_DECERTIFIED_DEVELOPERS)
 	public DecertifiedDeveloperResults getDecertifiedDevelopers() throws EntityRetrievalException{
 		DecertifiedDeveloperResults ddr = new DecertifiedDeveloperResults();
 		List<DecertifiedDeveloperDTO> dtoList = new ArrayList<DecertifiedDeveloperDTO>();

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/PendingCertifiedProductManagerImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/PendingCertifiedProductManagerImpl.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.acls.domain.BasePermission;
@@ -58,6 +59,7 @@ import gov.healthit.chpl.upload.certifiedProduct.CertifiedProductUploadHandlerFa
 import gov.healthit.chpl.util.CertificationResultRules;
 import gov.healthit.chpl.validation.certifiedProduct.CertifiedProductValidator;
 import gov.healthit.chpl.validation.certifiedProduct.CertifiedProductValidatorFactory;
+import gov.healthit.chpl.web.controller.results.PendingCertifiedProductResults;
 
 @Service
 public class PendingCertifiedProductManagerImpl implements PendingCertifiedProductManager {
@@ -92,13 +94,30 @@ public class PendingCertifiedProductManagerImpl implements PendingCertifiedProdu
 	@PostFilter("hasRole('ROLE_ADMIN') or "
 			+ "((hasRole('ROLE_ACB_ADMIN') or hasRole('ROLE_ACB_STAFF')) and "
 			+ "(hasPermission(filterObject, read) or hasPermission(filterObject, admin)))")
+	@Cacheable(CacheNames.GET_PENDING)
 	public List<PendingCertifiedProductDTO> getPending() {
 		CertificationStatusDTO statusDto = statusDao.getByStatusName("Pending");
 		List<PendingCertifiedProductDTO> products = pcpDao.findByStatus(statusDto.getId());
 		updateCertResults(products);
-		validate(products);
-		
+		validate(products);	
 		return products;
+	}
+	
+	@Override
+	@Transactional(readOnly = true)
+	@Cacheable(CacheNames.GET_PENDING_CERTIFIED_PRODUCT_RESULTS)
+	public PendingCertifiedProductResults getPendingCertifiedProductResults(List<PendingCertifiedProductDTO> products){
+		List<PendingCertifiedProductDetails> result = new ArrayList<PendingCertifiedProductDetails>();
+		for(PendingCertifiedProductDTO product : products) {
+			PendingCertifiedProductDetails pcpDetails = new PendingCertifiedProductDetails(product);
+			addAllVersionsToCmsCriterion(pcpDetails);
+			addAllMeasuresToCertificationCriteria(pcpDetails);
+			result.add(pcpDetails);
+		}
+		
+		PendingCertifiedProductResults results = new PendingCertifiedProductResults();
+		results.getPendingCertifiedProducts().addAll(result);
+		return results;
 	}
 	
 	@Override
@@ -208,7 +227,7 @@ public class PendingCertifiedProductManagerImpl implements PendingCertifiedProdu
 	@Transactional
 	@PreAuthorize("(hasRole('ROLE_ACB_STAFF') or hasRole('ROLE_ACB_ADMIN')) "
 			+ "and hasPermission(#acbId, 'gov.healthit.chpl.dto.CertificationBodyDTO', admin)")
-	@CacheEvict(value = CacheNames.findByStatus)
+	@CacheEvict(value = {CacheNames.GET_PENDING, CacheNames.GET_PENDING_CERTIFIED_PRODUCT_RESULTS}, allEntries = true)
 	public PendingCertifiedProductDTO createOrReplace(Long acbId, PendingCertifiedProductEntity toCreate) 
 		throws EntityRetrievalException, EntityCreationException, JsonProcessingException {
 		Long existingId = pcpDao.findIdByOncId(toCreate.getUniqueId());
@@ -241,7 +260,7 @@ public class PendingCertifiedProductManagerImpl implements PendingCertifiedProdu
 	@Transactional
 	@PreAuthorize("(hasRole('ROLE_ACB_ADMIN') or hasRole('ROLE_ACB_STAFF')) and "
 			+ "hasPermission(#pendingProductId, 'gov.healthit.chpl.dto.PendingCertifiedProductDTO', admin)")
-	@CacheEvict(value = CacheNames.findByStatus)
+	@CacheEvict(value = {CacheNames.GET_PENDING, CacheNames.GET_PENDING_CERTIFIED_PRODUCT_RESULTS}, allEntries = true)
 	public void reject(Long pendingProductId) throws EntityRetrievalException, JsonProcessingException, EntityCreationException {
 		
 		PendingCertifiedProductDTO pendingCpDto = pcpDao.findById(pendingProductId);
@@ -257,7 +276,7 @@ public class PendingCertifiedProductManagerImpl implements PendingCertifiedProdu
 	@Transactional
 	@PreAuthorize("(hasRole('ROLE_ACB_ADMIN') or hasRole('ROLE_ACB_STAFF')) and "
 			+ "hasPermission(#pendingProductId, 'gov.healthit.chpl.dto.PendingCertifiedProductDTO', admin)")
-	@CacheEvict(value = CacheNames.findByStatus)
+	@CacheEvict(value = {CacheNames.GET_PENDING, CacheNames.GET_PENDING_CERTIFIED_PRODUCT_RESULTS}, allEntries = true)
 	public void confirm(Long pendingProductId) throws EntityRetrievalException, JsonProcessingException, EntityCreationException {
 		
 		PendingCertifiedProductDTO pendingCpDto = pcpDao.findById(pendingProductId);

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/ProductManagerImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/ProductManagerImpl.java
@@ -73,7 +73,7 @@ public class ProductManagerImpl implements ProductManager {
 	@Override
 	@Transactional(readOnly = false)
 	@PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_ACB_ADMIN') or hasRole('ROLE_ACB_STAFF')")
-	@CacheEvict(value = {CacheNames.productNames, CacheNames.search, CacheNames.countMultiFilterSearchResults})
+	@CacheEvict(value = {CacheNames.PRODUCT_NAMES, CacheNames.SEARCH, CacheNames.COUNT_MULTI_FILTER_SEARCH_RESULTS}, allEntries=true)
 	public ProductDTO create(ProductDTO dto) throws EntityRetrievalException, EntityCreationException, JsonProcessingException {
 		//check that the developer of this product is Active
 		if(dto.getDeveloperId() == null) {
@@ -100,7 +100,7 @@ public class ProductManagerImpl implements ProductManager {
 	@Override
 	@Transactional(readOnly = false)
 	@PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_ACB_ADMIN') or hasRole('ROLE_ACB_STAFF')")
-	@CacheEvict(value = {CacheNames.productNames, CacheNames.search, CacheNames.countMultiFilterSearchResults})
+	@CacheEvict(value = {CacheNames.PRODUCT_NAMES, CacheNames.SEARCH, CacheNames.COUNT_MULTI_FILTER_SEARCH_RESULTS}, allEntries=true)
 	public ProductDTO update(ProductDTO dto, boolean lookForSuspiciousActivity) throws EntityRetrievalException, EntityCreationException, JsonProcessingException {
 		
 		ProductDTO beforeDTO = productDao.getById(dto.getId());
@@ -137,7 +137,7 @@ public class ProductManagerImpl implements ProductManager {
 	@Override
 	@Transactional(readOnly = false)
 	@PreAuthorize("hasRole('ROLE_ADMIN')")
-	@CacheEvict(value = {CacheNames.productNames, CacheNames.search, CacheNames.countMultiFilterSearchResults})
+	@CacheEvict(value = {CacheNames.PRODUCT_NAMES, CacheNames.SEARCH, CacheNames.COUNT_MULTI_FILTER_SEARCH_RESULTS}, allEntries=true)
 	public ProductDTO merge(List<Long> productIdsToMerge, ProductDTO toCreate) throws EntityRetrievalException, EntityCreationException, JsonProcessingException {
 		
 		List<ProductDTO> beforeProducts = new ArrayList<ProductDTO>();

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/ProductVersionManagerImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/ProductVersionManagerImpl.java
@@ -74,7 +74,7 @@ public class ProductVersionManagerImpl implements ProductVersionManager {
 	@Override
 	@Transactional(readOnly = false)
 	@PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_ACB_ADMIN') or hasRole('ROLE_ACB_STAFF')")
-	@CacheEvict(value = {CacheNames.search, CacheNames.countMultiFilterSearchResults})
+	@CacheEvict(value = {CacheNames.SEARCH, CacheNames.COUNT_MULTI_FILTER_SEARCH_RESULTS}, allEntries=true)
 	public ProductVersionDTO create(ProductVersionDTO dto) throws EntityRetrievalException, EntityCreationException, JsonProcessingException {
 		//check that the developer of this version is Active
 		if(dto.getProductId() == null) {
@@ -102,7 +102,7 @@ public class ProductVersionManagerImpl implements ProductVersionManager {
 	@Override
 	@Transactional(readOnly = false)
 	@PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_ACB_ADMIN') or hasRole('ROLE_ACB_STAFF')")
-	@CacheEvict(value = {CacheNames.search, CacheNames.countMultiFilterSearchResults})
+	@CacheEvict(value = {CacheNames.SEARCH, CacheNames.COUNT_MULTI_FILTER_SEARCH_RESULTS}, allEntries=true)
 	public ProductVersionDTO update(ProductVersionDTO dto) throws EntityRetrievalException, JsonProcessingException, EntityCreationException {
 		
 		ProductVersionDTO before = dao.getById(dto.getId());
@@ -127,7 +127,7 @@ public class ProductVersionManagerImpl implements ProductVersionManager {
 	@Override
 	@Transactional(readOnly = false)
 	@PreAuthorize("hasRole('ROLE_ADMIN')")
-	@CacheEvict(value = {CacheNames.search, CacheNames.countMultiFilterSearchResults})
+	@CacheEvict(value = {CacheNames.SEARCH, CacheNames.COUNT_MULTI_FILTER_SEARCH_RESULTS}, allEntries=true)
 	public ProductVersionDTO merge(List<Long> versionIdsToMerge, ProductVersionDTO toCreate) throws EntityRetrievalException, JsonProcessingException, EntityCreationException {
 		
 		List<ProductVersionDTO> beforeVersions = new ArrayList<ProductVersionDTO>();

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/SearchMenuManagerImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/SearchMenuManagerImpl.java
@@ -114,7 +114,7 @@ public class SearchMenuManagerImpl implements SearchMenuManager {
 	
 	@Transactional
 	@Override
-	@Cacheable(CacheNames.classificationNames)
+	@Cacheable(CacheNames.CLASSIFICATION_NAMES)
 	public Set<KeyValueModel> getClassificationNames() {
 		
 		List<ProductClassificationTypeDTO> classificationTypes = productClassificationTypeDAO.findAll();
@@ -129,7 +129,7 @@ public class SearchMenuManagerImpl implements SearchMenuManager {
 
 	@Transactional
 	@Override
-	@Cacheable(CacheNames.editionNames)
+	@Cacheable(CacheNames.EDITION_NAMES)
 	public Set<KeyValueModel> getEditionNames(Boolean simple) {
 		
 		List<CertificationEditionDTO> certificationEditions = certificationEditionDAO.findAll();
@@ -150,7 +150,7 @@ public class SearchMenuManagerImpl implements SearchMenuManager {
 
 	@Transactional
 	@Override
-	@Cacheable(CacheNames.certificationStatuses)
+	@Cacheable(CacheNames.CERTIFICATION_STATUSES)
 	public Set<KeyValueModel> getCertificationStatuses() {
 		List<CertificationStatusDTO> certificationStatuses = certificationStatusDao.findAll();
 		Set<KeyValueModel> results = new HashSet<KeyValueModel>();
@@ -164,7 +164,7 @@ public class SearchMenuManagerImpl implements SearchMenuManager {
 	
 	@Transactional
 	@Override
-	@Cacheable(CacheNames.practiceTypeNames)
+	@Cacheable(CacheNames.PRACTICE_TYPE_NAMES)
 	public Set<KeyValueModel> getPracticeTypeNames() {
 		
 		List<PracticeTypeDTO> practiceTypeDTOs = practiceTypeDAO.findAll();
@@ -179,7 +179,7 @@ public class SearchMenuManagerImpl implements SearchMenuManager {
 
 	@Transactional
 	@Override
-	@Cacheable(CacheNames.productNames)
+	@Cacheable(CacheNames.PRODUCT_NAMES)
 	public Set<KeyValueModelStatuses> getProductNames() {
 		
 		List<ProductDTO> productDTOs = this.productDAO.findAll();
@@ -194,7 +194,7 @@ public class SearchMenuManagerImpl implements SearchMenuManager {
 
 	@Transactional
 	@Override
-	@Cacheable(CacheNames.developerNames)
+	@Cacheable(CacheNames.DEVELOPER_NAMES)
 	public Set<KeyValueModelStatuses> getDeveloperNames() {
 		
 		List<DeveloperDTO> developerDTOs = this.developerDAO.findAll();
@@ -209,7 +209,7 @@ public class SearchMenuManagerImpl implements SearchMenuManager {
 
 	@Transactional
 	@Override
-	@Cacheable(CacheNames.certBodyNames)
+	@Cacheable(CacheNames.CERT_BODY_NAMES)
 	public Set<KeyValueModel> getCertBodyNames() {
 		
 		List<CertificationBodyDTO> dtos = this.certificationBodyDAO.findAll(false);
@@ -431,7 +431,7 @@ public class SearchMenuManagerImpl implements SearchMenuManager {
 	
 	@Transactional
 	@Override
-	@Cacheable(CacheNames.macrameasures)
+	@Cacheable(CacheNames.MACRA_MEASURES)
 	public Set<CriteriaSpecificDescriptiveModel> getMacraMeasures() {
 		List<MacraMeasureDTO> measureDtos = macraDao.findAll();
 		Set<CriteriaSpecificDescriptiveModel> measures = new HashSet<CriteriaSpecificDescriptiveModel>();
@@ -445,7 +445,7 @@ public class SearchMenuManagerImpl implements SearchMenuManager {
 	
 	@Transactional
 	@Override
-	@Cacheable(CacheNames.certificationCriterionNumbers)
+	@Cacheable(CacheNames.CERTIFICATION_CRITERION_NUMBERS)
 	public Set<DescriptiveModel> getCertificationCriterionNumbers(Boolean simple) throws EntityRetrievalException{
 
 		List<CertificationCriterionDTO> dtos = this.certificationCriterionDAO.findAll();
@@ -461,7 +461,7 @@ public class SearchMenuManagerImpl implements SearchMenuManager {
 	
 	@Transactional
 	@Override
-	@Cacheable(CacheNames.cqmCriterionNumbers)
+	@Cacheable(CacheNames.CQM_CRITERION_NUMBERS)
 	public Set<DescriptiveModel> getCQMCriterionNumbers(Boolean simple){
 
 		List<CQMCriterionDTO> dtos = this.cqmCriterionDAO.findAll();

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/SurveillanceManagerImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/SurveillanceManagerImpl.java
@@ -117,7 +117,7 @@ public class SurveillanceManagerImpl implements SurveillanceManager {
 	@PreAuthorize("hasRole('ROLE_ADMIN') or "
 			+ "((hasRole('ROLE_ACB_STAFF') or hasRole('ROLE_ACB_ADMIN')) "
 			+ "and hasPermission(#acbId, 'gov.healthit.chpl.dto.CertificationBodyDTO', admin))")
-	@CacheEvict(value = {CacheNames.search, CacheNames.countMultiFilterSearchResults})
+	@CacheEvict(value = {CacheNames.SEARCH, CacheNames.COUNT_MULTI_FILTER_SEARCH_RESULTS}, allEntries=true)
 	public Long createSurveillance(Long acbId, Surveillance surv) {
 		Long insertedId = null;
 		
@@ -154,7 +154,7 @@ public class SurveillanceManagerImpl implements SurveillanceManager {
 	@PreAuthorize("hasRole('ROLE_ADMIN') or "
 			+ "((hasRole('ROLE_ACB_STAFF') or hasRole('ROLE_ACB_ADMIN')) "
 			+ "and hasPermission(#acbId, 'gov.healthit.chpl.dto.CertificationBodyDTO', admin))")
-	@CacheEvict(value = {CacheNames.search, CacheNames.countMultiFilterSearchResults})
+	@CacheEvict(value = {CacheNames.SEARCH, CacheNames.COUNT_MULTI_FILTER_SEARCH_RESULTS}, allEntries=true)
 	public void updateSurveillance(Long acbId, Surveillance surv) {
 		try {
 			survDao.updateSurveillance(surv);
@@ -169,7 +169,7 @@ public class SurveillanceManagerImpl implements SurveillanceManager {
 	@PreAuthorize("hasRole('ROLE_ADMIN') or "
 			+ "((hasRole('ROLE_ACB_STAFF') or hasRole('ROLE_ACB_ADMIN')) "
 			+ "and hasPermission(#acbId, 'gov.healthit.chpl.dto.CertificationBodyDTO', admin))")
-	@CacheEvict(value = {CacheNames.search, CacheNames.countMultiFilterSearchResults})
+	@CacheEvict(value = {CacheNames.SEARCH, CacheNames.COUNT_MULTI_FILTER_SEARCH_RESULTS}, allEntries=true)
 	public void deleteSurveillance(Long acbId, Long survId) {		
 		Surveillance surv = new Surveillance();
 		surv.setId(survId);

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/TestingLabManagerImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/TestingLabManagerImpl.java
@@ -95,7 +95,7 @@ public class TestingLabManagerImpl extends ApplicationObjectSupport implements T
 	
 	@Transactional
 	@PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#atl, admin)")
-	@CacheEvict(value = CacheNames.search)
+	@CacheEvict(value = CacheNames.SEARCH, allEntries=true)
 	public TestingLabDTO update(TestingLabDTO atl) throws EntityRetrievalException, JsonProcessingException, EntityCreationException, UpdateTestingLabException {
 		
 		TestingLabDTO toUpdate = testingLabDAO.getById(atl.getId());

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/CertifiedProductController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/CertifiedProductController.java
@@ -281,18 +281,11 @@ public class CertifiedProductController {
 	@RequestMapping(value="/pending", method=RequestMethod.GET,
 			produces="application/json; charset=utf-8")
 	public @ResponseBody PendingCertifiedProductResults getPendingCertifiedProducts() throws EntityRetrievalException {		
-		List<PendingCertifiedProductDTO> allProductDtos = pcpManager.getPending();
-		
-		List<PendingCertifiedProductDetails> result = new ArrayList<PendingCertifiedProductDetails>();
-		for(PendingCertifiedProductDTO product : allProductDtos) {
-			PendingCertifiedProductDetails pcpDetails = new PendingCertifiedProductDetails(product);
-			pcpManager.addAllVersionsToCmsCriterion(pcpDetails);
-			pcpManager.addAllMeasuresToCertificationCriteria(pcpDetails);
-			result.add(pcpDetails);
-		}
-		
+		List<PendingCertifiedProductDTO> products = pcpManager.getPending();
 		PendingCertifiedProductResults results = new PendingCertifiedProductResults();
-		results.getPendingCertifiedProducts().addAll(result);
+		if(products != null){
+			results = pcpManager.getPendingCertifiedProductResults(products);
+		}
 		return results;
 	}
 	

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/CertifiedProductController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/CertifiedProductController.java
@@ -281,11 +281,17 @@ public class CertifiedProductController {
 	@RequestMapping(value="/pending", method=RequestMethod.GET,
 			produces="application/json; charset=utf-8")
 	public @ResponseBody PendingCertifiedProductResults getPendingCertifiedProducts() throws EntityRetrievalException {		
-		List<PendingCertifiedProductDTO> products = pcpManager.getPending();
-		PendingCertifiedProductResults results = new PendingCertifiedProductResults();
-		if(products != null){
-			results = pcpManager.getPendingCertifiedProductResults(products);
+		List<PendingCertifiedProductDTO> allProductDtos = pcpManager.getPending();
+				
+		List<PendingCertifiedProductDetails> result = new ArrayList<PendingCertifiedProductDetails>();
+		for(PendingCertifiedProductDTO product : allProductDtos) {
+			PendingCertifiedProductDetails pcpDetails = new PendingCertifiedProductDetails(product);
+			pcpManager.addAllVersionsToCmsCriterion(pcpDetails);
+			pcpManager.addAllMeasuresToCertificationCriteria(pcpDetails);
+			result.add(pcpDetails);
 		}
+		PendingCertifiedProductResults results = new PendingCertifiedProductResults();
+		results.getPendingCertifiedProducts().addAll(result);
 		return results;
 	}
 	

--- a/chpl/chpl-service/src/main/resources/ehCache.xml
+++ b/chpl/chpl-service/src/main/resources/ehCache.xml
@@ -165,7 +165,7 @@
 	<!-- end /search_options caching -->
 
 	<!-- /pending caching -->
-	<cache name="getByStatusName"
+	<cache name="getPending"
 		maxEntriesLocalHeap="10000"
 		maxEntriesLocalDisk="100000"
 		eternal="false"
@@ -176,7 +176,7 @@
 		<persistence strategy="localTempSwap" />
 	</cache>
 	
-	<cache name="findByStatus"
+	<cache name="getPendingCertifiedProductResults"
 		maxEntriesLocalHeap="10000"
 		maxEntriesLocalDisk="100000"
 		eternal="false"

--- a/chpl/chpl-service/src/main/resources/ehCache.xml
+++ b/chpl/chpl-service/src/main/resources/ehCache.xml
@@ -163,30 +163,6 @@
 		<persistence strategy="localTempSwap" />
 	</cache>
 	<!-- end /search_options caching -->
-
-	<!-- /pending caching -->
-	<cache name="getPending"
-		maxEntriesLocalHeap="10000"
-		maxEntriesLocalDisk="100000"
-		eternal="false"
-		diskSpoolBufferSizeMB="20"
-		timeToIdleSeconds="10800" timeToLiveSeconds="86400"
-		memoryStoreEvictionPolicy="LFU"
-		transactionalMode="off">
-		<persistence strategy="localTempSwap" />
-	</cache>
-	
-	<cache name="getPendingCertifiedProductResults"
-		maxEntriesLocalHeap="10000"
-		maxEntriesLocalDisk="100000"
-		eternal="false"
-		diskSpoolBufferSizeMB="20"
-		timeToIdleSeconds="10800" timeToLiveSeconds="86400"
-		memoryStoreEvictionPolicy="LFU"
-		transactionalMode="off">
-		<persistence strategy="localTempSwap" />
-	</cache>
-	<!-- end /pending caching -->
 	
 	<!-- /search caching -->
 	<cache name="search"

--- a/chpl/chpl-service/src/test/resources/ehCache-test.xml
+++ b/chpl/chpl-service/src/test/resources/ehCache-test.xml
@@ -176,8 +176,8 @@
 	<!-- end /search_options caching -->
 
 	<!-- /pending caching -->
-	<cache name="getByStatusName"
-		maxEntriesLocalHeap="1000"
+	<cache name="getPending"
+		maxEntriesLocalHeap="10000"
 		maxEntriesLocalDisk="100000"
 		eternal="false"
 		diskSpoolBufferSizeMB="20"
@@ -187,8 +187,8 @@
 		<persistence strategy="localTempSwap" />
 	</cache>
 	
-	<cache name="findByStatus"
-		maxEntriesLocalHeap="1000"
+	<cache name="getPendingCertifiedProductResults"
+		maxEntriesLocalHeap="10000"
 		maxEntriesLocalDisk="100000"
 		eternal="false"
 		diskSpoolBufferSizeMB="20"

--- a/chpl/chpl-service/src/test/resources/ehCache-test.xml
+++ b/chpl/chpl-service/src/test/resources/ehCache-test.xml
@@ -174,30 +174,6 @@
 		<persistence strategy="localTempSwap" />
 	</cache>
 	<!-- end /search_options caching -->
-
-	<!-- /pending caching -->
-	<cache name="getPending"
-		maxEntriesLocalHeap="10000"
-		maxEntriesLocalDisk="100000"
-		eternal="false"
-		diskSpoolBufferSizeMB="20"
-		timeToIdleSeconds="10800" timeToLiveSeconds="86400"
-		memoryStoreEvictionPolicy="LFU"
-		transactionalMode="off">
-		<persistence strategy="localTempSwap" />
-	</cache>
-	
-	<cache name="getPendingCertifiedProductResults"
-		maxEntriesLocalHeap="10000"
-		maxEntriesLocalDisk="100000"
-		eternal="false"
-		diskSpoolBufferSizeMB="20"
-		timeToIdleSeconds="10800" timeToLiveSeconds="86400"
-		memoryStoreEvictionPolicy="LFU"
-		transactionalMode="off">
-		<persistence strategy="localTempSwap" />
-	</cache>
-	<!-- end /pending caching -->
 	
 	<!-- /search caching -->
 	<cache name="search"


### PR DESCRIPTION
After discussions with Katy, we decided upon removing caching for /pending: it has a @PostFilter which could potentially result in a user seeing incorrect results; this, along with refactoring the /pending acl_class security to match the latest surveillance security, is a large enough effort that it should probably be a user story in the backlog.