### PR TITLE
OCD-1327: show error for broken Date Corrective Action Must Be Completed rule

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,12 @@
 _Date TBD_
 
 ### Features Added
+* Show error to ONC-ACB during upload and edit when Surveillance Activity has a nonconformity with an entry for "Date Corrective Action Plan Was Approved" but no entry for "Date Corrective Action Plan Must Be Completed" 
+
+## Version TBD
+_Date TBD_
+
+### Features Added
 * Add authority to surveillance to allow end user to tell whether ONC or ACB created a surveillance activity
 * Disallow saving of Surveillance without close date but with no open Non-Conformities
 * Improve performance of /surveillance/pending by ~643%

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/validation/surveillance/SurveillanceValidator.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/validation/surveillance/SurveillanceValidator.java
@@ -304,6 +304,11 @@ public class SurveillanceValidator {
 								nc.setStatus(ncStatus);
 							}
 						}
+						
+						if(!StringUtils.isEmpty(nc.getCapApprovalDate()) && StringUtils.isEmpty(nc.getCapMustCompleteDate())){
+							surv.getErrorMessages().add("Date Corrective Action Plan Must Be Completed is required for requirement " 
+						+ req.getRequirement() + ", nonconformity " + nc.getNonconformityType() + " when there is an entry for Date Corrective Action Plan Was Approved.");
+						}
 
 						if(nc.getDateOfDetermination() == null) {
 							surv.getErrorMessages().add("Date of determination is required for requirement " + req.getRequirement() + ", nonconformity " + nc.getNonconformityType());

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/web/controller/SurveillanceControllerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/web/controller/SurveillanceControllerTest.java
@@ -5,9 +5,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,6 +33,7 @@ import com.github.springtestdbunit.annotation.DatabaseSetup;
 
 import gov.healthit.chpl.auth.domain.Authority;
 import gov.healthit.chpl.auth.permission.GrantedPermission;
+import gov.healthit.chpl.auth.permission.UserPermissionRetrievalException;
 import gov.healthit.chpl.auth.user.JWTAuthenticatedUser;
 import gov.healthit.chpl.caching.UnitTestRules;
 import gov.healthit.chpl.dao.CertifiedProductDAO;
@@ -38,12 +42,15 @@ import gov.healthit.chpl.dao.EntityRetrievalException;
 import gov.healthit.chpl.dao.SurveillanceDAO;
 import gov.healthit.chpl.domain.CertifiedProduct;
 import gov.healthit.chpl.domain.Surveillance;
+import gov.healthit.chpl.domain.SurveillanceNonconformity;
+import gov.healthit.chpl.domain.SurveillanceNonconformityStatus;
 import gov.healthit.chpl.domain.SurveillanceRequirement;
 import gov.healthit.chpl.domain.SurveillanceRequirementType;
 import gov.healthit.chpl.domain.SurveillanceResultType;
 import gov.healthit.chpl.domain.SurveillanceType;
 import gov.healthit.chpl.dto.CertifiedProductDTO;
 import gov.healthit.chpl.manager.SurveillanceManager;
+import gov.healthit.chpl.manager.impl.SurveillanceAuthorityAccessDeniedException;
 import gov.healthit.chpl.web.controller.results.SurveillanceResults;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -1086,4 +1093,253 @@ public class SurveillanceControllerTest {
 		assertTrue(elapsedTime2 < elapsedTime);
 	}
 	
+	/** 
+	 * Given I am authenticated as ACB Admin
+	 * Given I have authority on the ACB
+	 * When I create a surveillance that has DateCorrectiveActionPlanWasApproved but no value for DateCorrectiveActionPlanMustBeCompleted
+	 * Then the validator adds an error
+	 * @throws ValidationException 
+	 * @throws EntityRetrievalException
+	 * @throws JsonProcessingException
+	 * @throws EntityCreationException
+	 * @throws InvalidArgumentsException
+	 * @throws ValidationException
+	 * @throws SurveillanceAuthorityAccessDeniedException 
+	 * @throws UserPermissionRetrievalException 
+	 * @throws CertificationBodyAccessException 
+	 */
+	@Transactional 
+	@Test
+	@Rollback
+	public void test_createSurveillance_hasDateCorrectiveActionPlanWasApproved_noDateCorrectiveActionPlanMustBeCompleted_returnsError()
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException, ValidationException, CertificationBodyAccessException, UserPermissionRetrievalException, SurveillanceAuthorityAccessDeniedException {
+		SecurityContextHolder.getContext().setAuthentication(acbAdmin);
+		Surveillance surv = new Surveillance();
+		
+		CertifiedProductDTO cpDto = cpDao.getById(1L);
+		CertifiedProduct cp = new CertifiedProduct();
+		cp.setId(cpDto.getId());
+		cp.setChplProductNumber(cp.getChplProductNumber());
+		cp.setEdition(cp.getEdition());
+		surv.setCertifiedProduct(cp);
+		surv.setStartDate(new Date());
+		surv.setRandomizedSitesUsed(10);
+		SurveillanceType type = survDao.findSurveillanceType("Randomized");
+		surv.setType(type);
+		surv.setAuthority(Authority.ROLE_ACB_ADMIN);
+		
+		SurveillanceRequirement req = new SurveillanceRequirement();
+		req.setRequirement("170.314 (a)(1)");
+		SurveillanceRequirementType reqType = survDao.findSurveillanceRequirementType("Certified Capability");
+		req.setType(reqType);
+		SurveillanceResultType resType = survDao.findSurveillanceResultType("Non-Conformity");
+		req.setResult(resType);
+		
+		List<SurveillanceNonconformity> ncs = new ArrayList<SurveillanceNonconformity>();
+		SurveillanceNonconformity nc = new SurveillanceNonconformity();
+		nc.setNonconformityType("170.523 (k)(1)");
+		SurveillanceNonconformityStatus survNcStatus = new SurveillanceNonconformityStatus();
+		survNcStatus.setName("Closed");
+		nc.setStatus(survNcStatus);
+		nc.setCapApprovalDate(new Date());
+		ncs.add(nc);
+		req.setNonconformities(ncs);
+		
+		surv.getRequirements().add(req);
+		
+		try {
+			surveillanceController.createSurveillance(surv);
+		} catch(ValidationException e){ 
+			assertTrue(StringUtils.containsIgnoreCase(e.getErrorMessages().toString(), "Date Corrective Action Plan Must Be Completed"));
+		}
+	}
+	
+	/** 
+	 * Given I am authenticated as ACB Admin
+	 * Given I have authority on the ACB
+	 * When I create a surveillance that has DateCorrectiveActionPlanWasApproved and a value for DateCorrectiveActionPlanMustBeCompleted
+	 * Then the validator does not add an error
+	 * @throws ValidationException 
+	 * @throws EntityRetrievalException
+	 * @throws JsonProcessingException
+	 * @throws EntityCreationException
+	 * @throws InvalidArgumentsException
+	 * @throws ValidationException
+	 * @throws SurveillanceAuthorityAccessDeniedException 
+	 * @throws UserPermissionRetrievalException 
+	 * @throws CertificationBodyAccessException 
+	 */
+	@Transactional 
+	@Test
+	@Rollback
+	public void test_createSurveillance_hasDateCorrectiveActionPlanWasApproved_hasDateCorrectiveActionPlanMustBeCompleted_returnsNoError()
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException, ValidationException, CertificationBodyAccessException, UserPermissionRetrievalException, SurveillanceAuthorityAccessDeniedException {
+		SecurityContextHolder.getContext().setAuthentication(acbAdmin);
+		Surveillance surv = new Surveillance();
+		
+		CertifiedProductDTO cpDto = cpDao.getById(1L);
+		CertifiedProduct cp = new CertifiedProduct();
+		cp.setId(cpDto.getId());
+		cp.setChplProductNumber(cp.getChplProductNumber());
+		cp.setEdition(cp.getEdition());
+		surv.setCertifiedProduct(cp);
+		surv.setStartDate(new Date());
+		surv.setRandomizedSitesUsed(10);
+		SurveillanceType type = survDao.findSurveillanceType("Randomized");
+		surv.setType(type);
+		surv.setAuthority(Authority.ROLE_ACB_ADMIN);
+		
+		SurveillanceRequirement req = new SurveillanceRequirement();
+		req.setRequirement("170.314 (a)(1)");
+		SurveillanceRequirementType reqType = survDao.findSurveillanceRequirementType("Certified Capability");
+		req.setType(reqType);
+		SurveillanceResultType resType = survDao.findSurveillanceResultType("Non-Conformity");
+		req.setResult(resType);
+		
+		List<SurveillanceNonconformity> ncs = new ArrayList<SurveillanceNonconformity>();
+		SurveillanceNonconformity nc = new SurveillanceNonconformity();
+		nc.setNonconformityType("170.523 (k)(1)");
+		SurveillanceNonconformityStatus survNcStatus = new SurveillanceNonconformityStatus();
+		survNcStatus.setName("Closed");
+		nc.setStatus(survNcStatus);
+		nc.setCapApprovalDate(new Date());
+		nc.setCapMustCompleteDate(new Date());
+		ncs.add(nc);
+		req.setNonconformities(ncs);
+		
+		surv.getRequirements().add(req);
+		
+		try {
+			surveillanceController.createSurveillance(surv);
+		} catch(ValidationException e){ 
+			assertFalse(StringUtils.containsIgnoreCase(e.getErrorMessages().toString(), "Date Corrective Action Plan Must Be Completed"));
+		}
+	}
+	
+	/** 
+	 * Given I am authenticated as ACB Admin
+	 * Given I have authority on the ACB
+	 * When I update a surveillance that has DateCorrectiveActionPlanWasApproved but no value for DateCorrectiveActionPlanMustBeCompleted
+	 * Then the validator adds an error
+	 * @throws ValidationException 
+	 * @throws EntityRetrievalException
+	 * @throws JsonProcessingException
+	 * @throws EntityCreationException
+	 * @throws InvalidArgumentsException
+	 * @throws ValidationException
+	 * @throws SurveillanceAuthorityAccessDeniedException 
+	 * @throws UserPermissionRetrievalException 
+	 * @throws CertificationBodyAccessException 
+	 */
+	@Transactional 
+	@Test
+	@Rollback
+	public void test_updateSurveillance_hasDateCorrectiveActionPlanWasApproved_noDateCorrectiveActionPlanMustBeCompleted_returnsError()
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException, ValidationException, CertificationBodyAccessException, UserPermissionRetrievalException, SurveillanceAuthorityAccessDeniedException {
+		SecurityContextHolder.getContext().setAuthentication(acbAdmin);
+		Surveillance surv = new Surveillance();
+		
+		CertifiedProductDTO cpDto = cpDao.getById(1L);
+		CertifiedProduct cp = new CertifiedProduct();
+		cp.setId(cpDto.getId());
+		cp.setChplProductNumber(cp.getChplProductNumber());
+		cp.setEdition(cp.getEdition());
+		surv.setCertifiedProduct(cp);
+		surv.setStartDate(new Date());
+		surv.setRandomizedSitesUsed(10);
+		SurveillanceType type = survDao.findSurveillanceType("Randomized");
+		surv.setType(type);
+		surv.setAuthority(Authority.ROLE_ACB_ADMIN);
+		
+		SurveillanceRequirement req = new SurveillanceRequirement();
+		req.setRequirement("170.314 (a)(1)");
+		SurveillanceRequirementType reqType = survDao.findSurveillanceRequirementType("Certified Capability");
+		req.setType(reqType);
+		SurveillanceResultType resType = survDao.findSurveillanceResultType("Non-Conformity");
+		req.setResult(resType);
+		
+		List<SurveillanceNonconformity> ncs = new ArrayList<SurveillanceNonconformity>();
+		SurveillanceNonconformity nc = new SurveillanceNonconformity();
+		nc.setNonconformityType("170.523 (k)(1)");
+		SurveillanceNonconformityStatus survNcStatus = new SurveillanceNonconformityStatus();
+		survNcStatus.setName("Closed");
+		nc.setStatus(survNcStatus);
+		nc.setCapApprovalDate(new Date());
+		ncs.add(nc);
+		req.setNonconformities(ncs);
+		
+		surv.getRequirements().add(req);
+		
+		try {
+			surveillanceController.updateSurveillance(surv);
+		} catch(ValidationException e){ 
+			assertTrue(StringUtils.containsIgnoreCase(e.getErrorMessages().toString(), "Date Corrective Action Plan Must Be Completed"));
+		}
+	}
+	
+	/** 
+	 * Given I am authenticated as ACB Admin
+	 * Given I have authority on the ACB
+	 * When I update a surveillance that has DateCorrectiveActionPlanWasApproved and a value for DateCorrectiveActionPlanMustBeCompleted
+	 * Then the validator does not add an error
+	 * @throws ValidationException 
+	 * @throws EntityRetrievalException
+	 * @throws JsonProcessingException
+	 * @throws EntityCreationException
+	 * @throws InvalidArgumentsException
+	 * @throws ValidationException
+	 * @throws SurveillanceAuthorityAccessDeniedException 
+	 * @throws UserPermissionRetrievalException 
+	 * @throws CertificationBodyAccessException 
+	 */
+	@Transactional 
+	@Test
+	@Rollback
+	public void test_updateSurveillance_hasDateCorrectiveActionPlanWasApproved_hasDateCorrectiveActionPlanMustBeCompleted_returnsNoError()
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException, ValidationException, CertificationBodyAccessException, UserPermissionRetrievalException, SurveillanceAuthorityAccessDeniedException {
+		SecurityContextHolder.getContext().setAuthentication(acbAdmin);
+		Surveillance surv = new Surveillance();
+		
+		CertifiedProductDTO cpDto = cpDao.getById(1L);
+		CertifiedProduct cp = new CertifiedProduct();
+		cp.setId(cpDto.getId());
+		cp.setChplProductNumber(cp.getChplProductNumber());
+		cp.setEdition(cp.getEdition());
+		surv.setCertifiedProduct(cp);
+		surv.setStartDate(new Date());
+		surv.setRandomizedSitesUsed(10);
+		SurveillanceType type = survDao.findSurveillanceType("Randomized");
+		surv.setType(type);
+		surv.setAuthority(Authority.ROLE_ACB_ADMIN);
+		
+		SurveillanceRequirement req = new SurveillanceRequirement();
+		req.setRequirement("170.314 (a)(1)");
+		SurveillanceRequirementType reqType = survDao.findSurveillanceRequirementType("Certified Capability");
+		req.setType(reqType);
+		SurveillanceResultType resType = survDao.findSurveillanceResultType("Non-Conformity");
+		req.setResult(resType);
+		
+		List<SurveillanceNonconformity> ncs = new ArrayList<SurveillanceNonconformity>();
+		SurveillanceNonconformity nc = new SurveillanceNonconformity();
+		nc.setNonconformityType("170.523 (k)(1)");
+		SurveillanceNonconformityStatus survNcStatus = new SurveillanceNonconformityStatus();
+		survNcStatus.setName("Closed");
+		nc.setStatus(survNcStatus);
+		nc.setCapApprovalDate(new Date());
+		nc.setCapMustCompleteDate(new Date());
+		ncs.add(nc);
+		req.setNonconformities(ncs);
+		
+		surv.getRequirements().add(req);
+		
+		try {
+			surveillanceController.updateSurveillance(surv);
+		} catch(ValidationException e){ 
+			assertFalse(StringUtils.containsIgnoreCase(e.getErrorMessages().toString(), "Date Corrective Action Plan Must Be Completed"));
+		}
+	}
 }


### PR DESCRIPTION
Creating PR for API now since it has a separate QA task and can/should be verified separately from the UI. This will be deployed to development only since staging is frozen until 3/29.