### PR TITLE
Fix broken unit test; refactor another that could break; clear caches before each unit test executes

### DIFF
--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/caching/PreFetchedCaches.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/caching/PreFetchedCaches.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import gov.healthit.chpl.dao.search.CertifiedProductSearchDAO;
-import gov.healthit.chpl.domain.search.BasicSearchResponse;
 import gov.healthit.chpl.domain.search.CertifiedProductFlatSearchResult;
 
 @Component

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/CertifiedProductSearchManager.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/CertifiedProductSearchManager.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import gov.healthit.chpl.domain.SearchRequest;
 import gov.healthit.chpl.domain.SearchResponse;
-import gov.healthit.chpl.domain.search.BasicSearchResponse;
 import gov.healthit.chpl.domain.search.CertifiedProductFlatSearchResult;
 
 

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/CertifiedProductSearchManagerImpl.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/impl/CertifiedProductSearchManagerImpl.java
@@ -15,7 +15,6 @@ import gov.healthit.chpl.dao.search.CertifiedProductSearchDAO;
 import gov.healthit.chpl.domain.CertifiedProductSearchResult;
 import gov.healthit.chpl.domain.SearchRequest;
 import gov.healthit.chpl.domain.SearchResponse;
-import gov.healthit.chpl.domain.search.BasicSearchResponse;
 import gov.healthit.chpl.domain.search.CertifiedProductFlatSearchResult;
 import gov.healthit.chpl.dto.CertifiedProductDetailsDTO;
 import gov.healthit.chpl.manager.CertifiedProductSearchManager;

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/dao/impl/AccessibilityStandardDaoTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/dao/impl/AccessibilityStandardDaoTest.java
@@ -2,6 +2,7 @@ package gov.healthit.chpl.dao.impl;
 
 
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,7 @@ import com.github.springtestdbunit.annotation.DatabaseSetup;
 
 import gov.healthit.chpl.auth.permission.GrantedPermission;
 import gov.healthit.chpl.auth.user.JWTAuthenticatedUser;
+import gov.healthit.chpl.caching.UnitTestRules;
 import gov.healthit.chpl.dao.AccessibilityStandardDAO;
 import gov.healthit.chpl.dao.EntityCreationException;
 import gov.healthit.chpl.dao.EntityRetrievalException;
@@ -40,6 +42,10 @@ public class AccessibilityStandardDaoTest extends TestCase {
 	@Autowired
 	private AccessibilityStandardDAO asDao;
 	private static JWTAuthenticatedUser adminUser;
+	
+	@Rule
+    @Autowired
+    public UnitTestRules cacheInvalidationRule;
 	
 	
 	@BeforeClass

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/dao/impl/ActivityDaoTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/dao/impl/ActivityDaoTest.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +24,7 @@ import com.github.springtestdbunit.annotation.DatabaseSetup;
 
 import gov.healthit.chpl.auth.permission.GrantedPermission;
 import gov.healthit.chpl.auth.user.JWTAuthenticatedUser;
+import gov.healthit.chpl.caching.UnitTestRules;
 import gov.healthit.chpl.dao.ActivityDAO;
 import gov.healthit.chpl.dao.EntityCreationException;
 import gov.healthit.chpl.dao.EntityRetrievalException;
@@ -46,6 +48,10 @@ public class ActivityDaoTest extends TestCase {
 	
 	
 	private static JWTAuthenticatedUser adminUser;
+	
+	@Rule
+    @Autowired
+    public UnitTestRules cacheInvalidationRule;
 	
 	
 	@BeforeClass

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/dao/impl/AddressDaoTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/dao/impl/AddressDaoTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 
+import gov.healthit.chpl.caching.UnitTestRules;
 import gov.healthit.chpl.dao.AddressDAO;
 import gov.healthit.chpl.dao.EntityCreationException;
 import gov.healthit.chpl.dao.EntityRetrievalException;
@@ -29,15 +31,18 @@ import junit.framework.TestCase;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = { gov.healthit.chpl.CHPLTestConfig.class })
-@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class,
-    DirtiesContextTestExecutionListener.class,
-    TransactionalTestExecutionListener.class,
-    DbUnitTestExecutionListener.class })
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, DirtiesContextTestExecutionListener.class,
+		TransactionalTestExecutionListener.class, DbUnitTestExecutionListener.class })
 @DatabaseSetup("classpath:data/testData.xml")
 public class AddressDaoTest extends TestCase {
 
-	@Autowired private AddressDAO addressDao;
-	
+	@Autowired
+	private AddressDAO addressDao;
+
+	@Rule
+	@Autowired
+	public UnitTestRules cacheInvalidationRule;
+
 	@Before
 	public void setUp() throws Exception {
 	}
@@ -49,7 +54,7 @@ public class AddressDaoTest extends TestCase {
 		assertNotNull(results);
 		assertEquals(2, results.size());
 	}
-	
+
 	@Test
 	@Transactional
 	public void getAddressById() throws EntityRetrievalException {
@@ -57,7 +62,7 @@ public class AddressDaoTest extends TestCase {
 		assertNotNull(result);
 		assertTrue(result.getId() == -1L);
 	}
-	
+
 	@Test
 	@Transactional
 	public void getAddressByValues() {
@@ -70,20 +75,21 @@ public class AddressDaoTest extends TestCase {
 		AddressDTO found = addressDao.getByValues(search);
 		assertNotNull(found);
 	}
+
 	@Test
 	public void getAddressByDeveloperId() {
 		Long developerId = -1L;
 		AddressDTO result = null;
 		try {
 			result = addressDao.getById(developerId);
-		} catch(EntityRetrievalException ex) {
+		} catch (EntityRetrievalException ex) {
 			fail("Could not find address with the id");
 		}
 		assertNotNull(result);
 		assertNotNull(result.getId());
 		assertEquals(-1, result.getId().longValue());
 	}
-	
+
 	@Test
 	public void updateAddress() throws EntityRetrievalException {
 		AddressDTO toUpdate = addressDao.getById(-1L);
@@ -93,27 +99,28 @@ public class AddressDaoTest extends TestCase {
 		assertNotNull(toUpdate);
 		assertEquals("Annapolis", toUpdate.getCity());
 	}
-	
-	
+
 	@Test
 	@Ignore
 	@Transactional
 	@Rollback
-	// The AddressDAOImpl.update(AddressDTO) does not handle empty city string; thus, this test should always fail. Ignoring
+	// The AddressDAOImpl.update(AddressDTO) does not handle empty city string;
+	// thus, this test should always fail. Ignoring
 	public void updateAddressWithEmptyCity() throws EntityRetrievalException {
 		AddressDTO toUpdate = addressDao.getById(-1L);
 		toUpdate.setCity("");
-		
+
 		try {
 			addressDao.update(toUpdate);
 			fail("did not catch empty string constraint!");
-		} catch(Exception ex) {}
-		
+		} catch (Exception ex) {
+		}
+
 		AddressDTO notUpdated = addressDao.getById(-1L);
 		assertNotNull(notUpdated);
 		assertEquals("Baltimore", notUpdated.getCity());
 	}
-	
+
 	@Test
 	@Transactional
 	@Rollback
@@ -128,26 +135,24 @@ public class AddressDaoTest extends TestCase {
 		newAddress.setCreationDate(new Date());
 		newAddress.setLastModifiedDate(new Date());
 		newAddress.setDeleted(false);
-		
+
 		AddressEntity result = null;
-		try
-		{
+		try {
 			result = addressDao.create(newAddress);
-		} catch(EntityRetrievalException ex) {
+		} catch (EntityRetrievalException ex) {
 			fail("retrieval exception");
-		} catch(EntityCreationException crex) {
+		} catch (EntityCreationException crex) {
 			fail("creation exception");
 		}
-		
+
 		assertNotNull(result);
 		assertNotNull(result.getId());
-		
-		//try to look up the created thing
-		try
-		{
+
+		// try to look up the created thing
+		try {
 			AddressDTO inserted = addressDao.getById(result.getId());
 			assertNotNull(inserted);
-		} catch(EntityRetrievalException ex) {
+		} catch (EntityRetrievalException ex) {
 			fail("could not find address with id " + result.getId());
 		}
 	}

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/dao/impl/CorrectiveActionDaoTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/dao/impl/CorrectiveActionDaoTest.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +24,7 @@ import com.github.springtestdbunit.annotation.DatabaseSetup;
 
 import gov.healthit.chpl.auth.permission.GrantedPermission;
 import gov.healthit.chpl.auth.user.JWTAuthenticatedUser;
+import gov.healthit.chpl.caching.UnitTestRules;
 import gov.healthit.chpl.dao.CertificationCriterionDAO;
 import gov.healthit.chpl.dao.CorrectiveActionPlanCertificationResultDAO;
 import gov.healthit.chpl.dao.CorrectiveActionPlanDAO;
@@ -50,6 +52,10 @@ public class CorrectiveActionDaoTest extends TestCase {
 	private CorrectiveActionPlanCertificationResultDAO capCertDao;
 	@Autowired
 	private CertificationCriterionDAO certDao;
+	
+	@Rule
+    @Autowired
+    public UnitTestRules cacheInvalidationRule;
 	
 	private static JWTAuthenticatedUser adminUser;
 	

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/dao/impl/MacraMeasureDaoTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/dao/impl/MacraMeasureDaoTest.java
@@ -3,6 +3,7 @@ package gov.healthit.chpl.dao.impl;
 import java.util.List;
 
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 
+import gov.healthit.chpl.caching.UnitTestRules;
 import gov.healthit.chpl.dao.MacraMeasureDAO;
 import gov.healthit.chpl.dto.MacraMeasureDTO;
 import junit.framework.TestCase;
@@ -32,6 +34,10 @@ public class MacraMeasureDaoTest extends TestCase {
 
 	@Autowired 
 	private MacraMeasureDAO macraDao;
+	
+	@Rule
+    @Autowired
+    public UnitTestRules cacheInvalidationRule;
 	
 	@BeforeClass
 	public static void setUpClass() throws Exception {

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/dto/DecertifiedDeveloperDTOTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/dto/DecertifiedDeveloperDTOTest.java
@@ -7,8 +7,10 @@ import java.util.Date;
 import java.util.List;
 
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -22,6 +24,7 @@ import com.github.springtestdbunit.annotation.DatabaseSetup;
 
 import gov.healthit.chpl.auth.permission.GrantedPermission;
 import gov.healthit.chpl.auth.user.JWTAuthenticatedUser;
+import gov.healthit.chpl.caching.UnitTestRules;
 import gov.healthit.chpl.entity.DeveloperStatusType;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -34,6 +37,10 @@ import gov.healthit.chpl.entity.DeveloperStatusType;
 public class DecertifiedDeveloperDTOTest {
 	
 	private static JWTAuthenticatedUser authUser;
+	
+	@Rule
+    @Autowired
+    public UnitTestRules cacheInvalidationRule;
 	
 	@BeforeClass
 	public static void setUpClass() throws Exception {

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/manager/impl/ActivityManagerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/manager/impl/ActivityManagerTest.java
@@ -48,7 +48,6 @@ import junit.framework.TestCase;
     DbUnitTestExecutionListener.class })
 @DatabaseSetup("classpath:data/testData.xml")
 public class ActivityManagerTest extends TestCase {
-	
 	@Autowired
 	private ActivityManager activityManager;
 	
@@ -57,7 +56,6 @@ public class ActivityManagerTest extends TestCase {
 	@Rule
     @Autowired
     public UnitTestRules cacheInvalidationRule;
-	
 	
 	@BeforeClass
 	public static void setUpClass() throws Exception {
@@ -68,7 +66,6 @@ public class ActivityManagerTest extends TestCase {
 		adminUser.setSubjectName("admin");
 		adminUser.getPermissions().add(new GrantedPermission("ROLE_ADMIN"));
 	}
-	
 	
 	@Test
 	@Transactional

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/manager/impl/ApiKeyManagerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/manager/impl/ApiKeyManagerTest.java
@@ -4,6 +4,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +24,7 @@ import com.github.springtestdbunit.annotation.DatabaseSetup;
 
 import gov.healthit.chpl.auth.permission.GrantedPermission;
 import gov.healthit.chpl.auth.user.JWTAuthenticatedUser;
+import gov.healthit.chpl.caching.UnitTestRules;
 import gov.healthit.chpl.dao.EntityCreationException;
 import gov.healthit.chpl.dao.EntityRetrievalException;
 import gov.healthit.chpl.dao.impl.ApiKeyActivityDAOImpl;
@@ -50,6 +52,10 @@ public class ApiKeyManagerTest extends TestCase {
 	private ApiKeyActivityDAOImpl apiKeyActivityDAOImpl;
 	
 	private static JWTAuthenticatedUser adminUser;
+	
+	@Rule
+    @Autowired
+    public UnitTestRules cacheInvalidationRule;
 	
 	@BeforeClass
 	public static void setUpClass() throws Exception {

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/manager/impl/CertifiedProductSearchManagerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/manager/impl/CertifiedProductSearchManagerTest.java
@@ -22,7 +22,6 @@ import gov.healthit.chpl.caching.UnitTestRules;
 import gov.healthit.chpl.domain.CertifiedProductSearchResult;
 import gov.healthit.chpl.domain.SearchRequest;
 import gov.healthit.chpl.domain.SearchResponse;
-import gov.healthit.chpl.domain.search.BasicSearchResponse;
 import gov.healthit.chpl.domain.search.CertifiedProductBasicSearchResult;
 import gov.healthit.chpl.domain.search.CertifiedProductFlatSearchResult;
 import gov.healthit.chpl.manager.CertifiedProductSearchManager;

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/web/controller/ActivityControllerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/web/controller/ActivityControllerTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +24,7 @@ import com.github.springtestdbunit.annotation.DatabaseSetup;
 
 import gov.healthit.chpl.auth.permission.GrantedPermission;
 import gov.healthit.chpl.auth.user.JWTAuthenticatedUser;
+import gov.healthit.chpl.caching.UnitTestRules;
 import gov.healthit.chpl.dao.EntityCreationException;
 import gov.healthit.chpl.dao.EntityRetrievalException;
 import gov.healthit.chpl.domain.ActivityEvent;
@@ -38,6 +40,10 @@ public class ActivityControllerTest {
 	private static JWTAuthenticatedUser adminUser;
 	
 	@Autowired ActivityController activityController;
+	
+	@Rule
+    @Autowired
+    public UnitTestRules cacheInvalidationRule;
 	
 	@BeforeClass
 	public static void setUpClass() throws Exception {

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/web/controller/ApiKeyControllerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/web/controller/ApiKeyControllerTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +26,7 @@ import com.github.springtestdbunit.annotation.DatabaseSetup;
 
 import gov.healthit.chpl.auth.permission.GrantedPermission;
 import gov.healthit.chpl.auth.user.JWTAuthenticatedUser;
+import gov.healthit.chpl.caching.UnitTestRules;
 import gov.healthit.chpl.dao.EntityCreationException;
 import gov.healthit.chpl.dao.EntityRetrievalException;
 import gov.healthit.chpl.domain.ApiKeyActivity;
@@ -44,6 +46,10 @@ public class ApiKeyControllerTest {
 	
 	@Autowired
 	private ApiKeyTestHelper apiKeyActivityTestHelper;
+	
+	@Rule
+    @Autowired
+    public UnitTestRules cacheInvalidationRule;
 	
 	private static JWTAuthenticatedUser adminUser;
 	

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/web/controller/MeaningfulUseControllerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/web/controller/MeaningfulUseControllerTest.java
@@ -168,44 +168,49 @@ public class MeaningfulUseControllerTest extends TestCase {
 		input.close();
 		file.delete();
 		
-		assertTrue("MeaningfulUseUserResults should return 4 but returned " + apiResult.getMeaningfulUseUsers().size(), apiResult.getMeaningfulUseUsers().size() == 4);
-		assertTrue("Errors should return 4 but returned " + apiResult.getErrors().size(), apiResult.getErrors().size() == 4);
-		assertTrue("MeaningfulUseUserResults returned " + apiResult.getMeaningfulUseUsers().get(0).getProductNumber() + " but should return CHP-024050", 
-				apiResult.getMeaningfulUseUsers().get(0).getProductNumber().equals("CHP-024050"));
-		assertTrue("MeaningfulUseUserResults returned " + apiResult.getMeaningfulUseUsers().get(0).getNumberOfUsers() + " but should return " + 10L, 
-				apiResult.getMeaningfulUseUsers().get(0).getNumberOfUsers().equals(10L));
-		assertTrue("MeaningfulUseUserResults returned " + apiResult.getMeaningfulUseUsers().get(0).getCertifiedProductId() + " but should return certifiedProductId 1", 
-				apiResult.getMeaningfulUseUsers().get(0).getCertifiedProductId() == 1);
-		assertTrue("MeaningfulUseUserResults should return correct product number", apiResult.getMeaningfulUseUsers().get(1).getProductNumber().equals("CHP-024051"));
-		assertTrue("MeaningfulUseUserResults should return correct numMeaningfulUseUsers", apiResult.getMeaningfulUseUsers().get(1).getNumberOfUsers().equals(20L));
-		assertTrue("MeaningfulUseUserResults should return correct product number", apiResult.getMeaningfulUseUsers().get(2).getProductNumber().equals("CHP-024052"));
-		assertTrue("MeaningfulUseUserResults should return correct numMeaningfulUseUsers", apiResult.getMeaningfulUseUsers().get(2).getNumberOfUsers().equals(30L));
-		assertTrue("MeaningfulUseUserResults should return correct product number", apiResult.getMeaningfulUseUsers().get(3).getProductNumber().equals("15.01.01.1009.EIC08.36.1.1.160402"));
-		assertTrue("MeaningfulUseUserResults should return correct numMeaningfulUseUsers", apiResult.getMeaningfulUseUsers().get(3).getNumberOfUsers().equals(40L));
-		assertTrue("MeaningfulUseUserResults returned " + apiResult.getMeaningfulUseUsers().get(3).getProductNumber() + " but should return 15.01.01.1009.EIC08.36.1.1.160402", 
-				apiResult.getMeaningfulUseUsers().get(3).getProductNumber().equals("15.01.01.1009.EIC08.36.1.1.160402"));
-		assertTrue("MeaningfulUseUserResults returned " + apiResult.getMeaningfulUseUsers().get(3).getNumberOfUsers() + " but should return " + 40L, 
-				apiResult.getMeaningfulUseUsers().get(3).getNumberOfUsers().equals(40L));
-		assertTrue("MeaningfulUseUserResults errors array should return incorrect CHPL Product Number for row with {wrongChplProductNumber, 50L} but returned " 
-		+ apiResult.getErrors().get(0).getError(), apiResult.getErrors().get(0).getError() != null);
-		assertTrue("MeaningfulUseUserResults errors array should return incorrect CHPL Product Number for row with {CHPL-024053, 60L} but returned " 
-				+ apiResult.getErrors().get(1).getError(), apiResult.getErrors().get(1).getError() != null);
-		assertTrue("MeaningfulUseUserResults errors array for row {CHPL-024053, 60L} should have Product Number CHPL-024053 but has " 
-				+ apiResult.getErrors().get(1).getProductNumber(), apiResult.getErrors().get(1).getProductNumber().equals("CHPL-024053"));
-		assertTrue("MeaningfulUseUserResults errors array for row {CHPL-024053, 60L} should have num_meaningful_use 60L but has " 
-				+ apiResult.getErrors().get(1).getNumberOfUsers(), apiResult.getErrors().get(1).getNumberOfUsers() == 60L);
-		assertTrue("MeaningfulUseUserResults errors array should return incorrect CHPL Product Number for row with {15.02.03.9876.AB01.01.0.1.123456, 70L} but returned " 
-				+ apiResult.getErrors().get(2).getError(), apiResult.getErrors().get(2).getError() != null);
-		assertTrue("MeaningfulUseUserResults errors array for row {15.02.03.9876.AB01.01.0.1.123456, 70L} should have Product Number 15.02.03.9876.AB01.01.0.1.123456 but has " 
-				+ apiResult.getErrors().get(2).getProductNumber(), apiResult.getErrors().get(2).getProductNumber().equals("15.02.03.9876.AB01.01.0.1.123456"));
-		assertTrue("MeaningfulUseUserResults errors array for row {15.02.03.9876.AB01.01.0.1.123456, 70L} should have num_meaningful_use 70L but has " 
-				+ apiResult.getErrors().get(2).getNumberOfUsers(), apiResult.getErrors().get(2).getNumberOfUsers() == 70L);
-		assertTrue("MeaningfulUseUserResults errors array should return incorrect CHPL Product Number for row with {15.01.01.1009.EIC08.36.1.1.160402, 70L} but returned " 
-				+ apiResult.getErrors().get(3).getError(), apiResult.getErrors().get(3).getError() != null);
-		assertTrue("MeaningfulUseUserResults errors array for row {12.01.01.1234.AB01.01.0.1.123456, 70L} should have Product Number 15.01.01.1009.EIC08.36.1.1.160402 but has " 
-				+ apiResult.getErrors().get(3).getProductNumber(), apiResult.getErrors().get(3).getProductNumber().equals("15.01.01.1009.EIC08.36.1.1.160402"));
-		assertTrue("MeaningfulUseUserResults errors array for row {15.01.01.1009.EIC08.36.1.1.160402, 70L} should have num_meaningful_use 70L but has " 
-				+ apiResult.getErrors().get(3).getNumberOfUsers(), apiResult.getErrors().get(3).getNumberOfUsers() == 70L);
+		for(MeaningfulUseUser muu : apiResult.getMeaningfulUseUsers()){
+			if(muu.getProductNumber().equals("CHP-024050")){
+				assertTrue(muu.getNumberOfUsers() == 10L);
+				assertTrue(muu.getCertifiedProductId() == 1L);
+			}
+			else if(muu.getProductNumber().equals("CHP-024051")){
+				assertTrue(muu.getNumberOfUsers() == 20L);
+				assertTrue(muu.getCertifiedProductId() == 2L);
+			}
+			else if(muu.getProductNumber().equals("CHP-024052")){
+				assertTrue(muu.getNumberOfUsers() == 30L);
+				assertTrue(muu.getCertifiedProductId() == 3L);
+			}
+			else if(muu.getProductNumber().equals("15.01.01.1009.EIC08.36.1.1.160402")){
+				assertTrue(muu.getNumberOfUsers() == 40L);
+				assertTrue(muu.getCertifiedProductId() == 5L);
+			}
+			else if(muu.getProductNumber().equals("14.01.01.1009.EIC08.36.1.1.160402")){
+				assertTrue(muu.getNumberOfUsers() == 50L);
+				assertTrue(muu.getCertifiedProductId() == 1L);
+			}
+		}
+		
+		for(MeaningfulUseUser muu : apiResult.getErrors()){
+			Boolean hasError = false;
+			if(muu.getProductNumber().equals("wrongChplProductNumber")){
+				assertTrue(muu.getNumberOfUsers() == 50L);
+				hasError=true;
+			}
+			else if(muu.getProductNumber().equals("CHPL-024053")){
+				assertTrue(muu.getNumberOfUsers() == 60L);
+				hasError=true;
+			}
+			else if(muu.getProductNumber().equals("15.02.03.9876.AB01.01.0.1.123456")){
+				assertTrue(muu.getNumberOfUsers() == 70L);
+				hasError=true;
+			}
+			else if(muu.getProductNumber().equals("15.01.01.1009.EIC08.36.1.1.160402")){
+				assertTrue(muu.getNumberOfUsers() == 70L);
+				hasError=true;
+			}
+			assertTrue(hasError);
+		}
 	}
 	
 	/** 

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/web/controller/SearchViewControllerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/web/controller/SearchViewControllerTest.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +25,7 @@ import com.github.springtestdbunit.annotation.DatabaseSetup;
 
 import gov.healthit.chpl.auth.permission.GrantedPermission;
 import gov.healthit.chpl.auth.user.JWTAuthenticatedUser;
+import gov.healthit.chpl.caching.UnitTestRules;
 import gov.healthit.chpl.dao.EntityCreationException;
 import gov.healthit.chpl.dao.EntityRetrievalException;
 import gov.healthit.chpl.domain.CertifiedProductSearchDetails;
@@ -34,7 +36,6 @@ import gov.healthit.chpl.domain.SearchRequest;
 import gov.healthit.chpl.domain.SearchResponse;
 import gov.healthit.chpl.domain.search.BasicSearchResponse;
 import gov.healthit.chpl.domain.search.CertifiedProductFlatSearchResult;
-import gov.healthit.chpl.domain.search.SearchViews;
 import gov.healthit.chpl.entity.CertificationStatusType;
 import gov.healthit.chpl.web.controller.results.DecertifiedDeveloperResults;
 import junit.framework.TestCase;
@@ -49,6 +50,10 @@ import junit.framework.TestCase;
 public class SearchViewControllerTest extends TestCase {
 	@Autowired
 	SearchViewController searchViewController = new SearchViewController();
+	
+	@Rule
+    @Autowired
+    public UnitTestRules cacheInvalidationRule;
 
 	private static JWTAuthenticatedUser adminUser;
 	


### PR DESCRIPTION
Fixes test_uploadMeaningfulUseUsers_noHeader_runsWithoutError that was failing randomly because of using object.get(int index). Also refactored a related unit test, test_uploadMeaningfulUseUsers_returnsMeaningfulUseUserResults, that also used object.get(int index),