### PR TITLE
OCD-1352: update GET /search endpoint to allow all params as POST

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## Version TBD Next
+_Date TBD Next
+
+### Features Added
+* Update parameters for HTTP GET /search call. All the same options that were previously available only to POST exist for the GET. Updated related API documentation.
+
+---
+
 ## Version TBD
 _Date TBD_
 

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/SearchViewController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/SearchViewController.java
@@ -11,11 +11,13 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.xml.crypto.dsig.keyinfo.KeyValue;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -36,8 +38,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import gov.healthit.chpl.dao.CertifiedProductSearchResultDAO;
 import gov.healthit.chpl.dao.EntityRetrievalException;
+import gov.healthit.chpl.domain.CertificationCriterion;
 import gov.healthit.chpl.domain.CertifiedProductSearchDetails;
 import gov.healthit.chpl.domain.CriteriaSpecificDescriptiveModel;
+import gov.healthit.chpl.domain.DescriptiveModel;
 import gov.healthit.chpl.domain.KeyValueModel;
 import gov.healthit.chpl.domain.KeyValueModelStatuses;
 import gov.healthit.chpl.domain.PopulateSearchOptions;
@@ -45,6 +49,7 @@ import gov.healthit.chpl.domain.SearchOption;
 import gov.healthit.chpl.domain.SearchRequest;
 import gov.healthit.chpl.domain.SearchResponse;
 import gov.healthit.chpl.domain.SurveillanceRequirementOptions;
+import gov.healthit.chpl.domain.SurveillanceSearchOptions;
 import gov.healthit.chpl.domain.search.BasicSearchResponse;
 import gov.healthit.chpl.domain.search.CertifiedProductFlatSearchResult;
 import gov.healthit.chpl.domain.search.CertifiedProductSearchResult;
@@ -56,6 +61,8 @@ import gov.healthit.chpl.manager.DeveloperManager;
 import gov.healthit.chpl.manager.SearchMenuManager;
 import gov.healthit.chpl.web.controller.results.DecertifiedDeveloperResults;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 
 @Api
@@ -264,39 +271,286 @@ public class SearchViewController {
 	}
 	
 	@ApiOperation(value="Search the CHPL", 
-			notes="If paging parameters are not specified, the first 20 records are returned by default.")
+			notes="If paging parameters are not specified, the first 20 records are returned by default. "
+			+ "All parameters are optional. "
+			+ "Note that Retired products are not included by default, so to see 2011 products (all of which are retired) "
+			+ "both the certificationEditions and certificationStatuses parameters must be provided - ex: "
+			+ "?certificationEditions=2011&certificationStatuses=Retired ."
+			+ "Any parameter that can accept multiple things (i.e. certificationStatuses) expects a comma-delimited list of those things (i.e. certificationStatuses=Active,Suspended). "
+			+ "Date parameters are required to be in the format " + SearchRequest.CERTIFICATION_DATE_SEARCH_FORMAT + ". ")
+	 @ApiImplicitParams({
+		    @ApiImplicitParam(name = "searchTerm", value = "CHPL ID, Developer Name, Product Name, ACB Certifiation ID", required = false, dataType = "string", paramType = "query"),
+		    @ApiImplicitParam(name = "certificationStatuses", value = "A comma-separated list of certification statuses "
+		    		+ "(ex: \"Active,Retired,Withdrawn by Developer\")). Retired listings are excluded unless requested with this parameter.", required = false, dataType = "string", paramType = "query"),
+		    @ApiImplicitParam(name = "certificationEditions", value = "A comma-separated list of certification editions (ex: \"2014,2015\").", required = false, dataType = "string", paramType = "query"),
+		    @ApiImplicitParam(name = "certificationCriteria", value = "A comma-separated list of certification criteria (ex: \"170.314 (a)(1),170.314 (a)(2)\").", 
+		    	required = false, dataType = "string", paramType = "query"),
+		    @ApiImplicitParam(name = "cqms", value = "A comma-separated list of cqms (ex: \"CMS2,CMS9\").", 
+		    	required = false, dataType = "string", paramType = "query"),
+		    @ApiImplicitParam(name = "certificationBodies", value = "A comma-separated list of certification body names (ex: \"Drummond,ICSA\").", 
+		    	required = false, dataType = "string", paramType = "query"),
+		    @ApiImplicitParam(name = "surveillance", value = "A comma-separated list of surveillance options "
+		    	+ "(ex: \"OPEN_SURVEILLANCE,CLOSED_SURVEILLANCE,OPEN_NONCONFORMITY,CLOSED_NONCONFORMITY\").", 
+	    		required = false, dataType = "string", paramType = "query"),
+		    @ApiImplicitParam(name = "hasHadSurveillance", value = "True or False if a listing has ever had surveillance.", 
+	    		required = false, dataType = "boolean", paramType = "query"),
+		    @ApiImplicitParam(name = "developer", value = "The full name of a developer.", 
+	    		required = false, dataType = "string", paramType = "query"),		
+		    @ApiImplicitParam(name = "product", value = "The full name of a product.", 
+    			required = false, dataType = "string", paramType = "query"),
+		    @ApiImplicitParam(name = "version", value = "The full name of a version.", 
+				required = false, dataType = "string", paramType = "query"),
+		    @ApiImplicitParam(name = "practiceType", value = "A practice type (either Ambulatory or Inpatient). Valid only for 2014 listings.", 
+				required = false, dataType = "string", paramType = "query"),
+		    @ApiImplicitParam(name = "certificationDateStart", value = "To return only listings certified after this date. Required format is " + SearchRequest.CERTIFICATION_DATE_SEARCH_FORMAT, 
+				required = false, dataType = "string", paramType = "query"),
+		    @ApiImplicitParam(name = "certificationDateEnd", value = "To return only listings certified before this date. Required format is " + SearchRequest.CERTIFICATION_DATE_SEARCH_FORMAT, 
+				required = false, dataType = "string", paramType = "query"),	
+		    @ApiImplicitParam(name = "pageNumber", value = "Zero-based page number used in concert with pageSize. Defaults to 0.", 
+				required = false, dataType = "string", paramType = "query"),
+		    @ApiImplicitParam(name = "pageSize", value = "Number of results to return used in concert with pageNumber. Defaults to 20.", 
+				required = false, dataType = "string", paramType = "query"),
+		    @ApiImplicitParam(name = "orderBy", value = "What to search by. Options are one of the following: " 
+		    	+ "developer, product, version, certificationEdition, productClassification, certificationBody, "
+		    	+ "certificationDate, or practiceType. Defaults to product.",
+				required = false, dataType = "string", paramType = "query"),
+		    @ApiImplicitParam(name = "sortDescending", value = "Use to specify the direction of the sort. Defaults to false (ascending sort).",
+				required = false, dataType = "boolean", paramType = "query")		    
+		  })
 	@RequestMapping(value="/search", method=RequestMethod.GET,
 			produces={"application/json; charset=utf-8", "application/xml"})
 	public @ResponseBody SearchResponse simpleSearch(
-			@RequestParam("searchTerm") String searchTerm, 
-			@RequestParam(value = "pageNumber", required = false) Integer pageNumber, 
-			@RequestParam(value = "pageSize", required = false) Integer pageSize,
-			@RequestParam(value = "orderBy", required = false) String orderBy,
-			@RequestParam(value = "sortDescending", required = false) Boolean sortDescending
-			) throws EntityRetrievalException {
-		
-		
-		if (pageNumber == null){
-			pageNumber = 0;
-		}
-		
-		if (pageSize == null){
-			pageSize = 20;
-		}
+			@RequestParam(value = "searchTerm", required=false) String searchTerm, 
+			@RequestParam(value = "certificationStatuses", required = false) String certificationStatusesDelimited,
+			@RequestParam(value="certificationEditions", required=false) String certificationEditionsDelimited,
+			@RequestParam(value="certificationCriteria", required=false) String certificationCriteriaDelimited,
+			@RequestParam(value="cqms", required=false) String cqmsDelimited,
+			@RequestParam(value="certificationBodies", required=false) String certificationBodiesDelimited,
+			@RequestParam(value="surveillance", required=false) String surveillanceDelimited,
+			@RequestParam(value="hasHadSurveillance", required=false) Boolean hasHadSurveillance,
+			@RequestParam(value="developer", required=false) String developer,
+			@RequestParam(value="product", required=false) String product,
+			@RequestParam(value="version", required=false) String version,
+			@RequestParam(value="practiceType", required=false) String practiceType,
+			@RequestParam(value = "certificationDateStart", required = false) String certificationDateStart,
+			@RequestParam(value = "certificationDateEnd", required = false) String certificationDateEnd,
+			@RequestParam(value = "pageNumber", required = false, defaultValue="0") Integer pageNumber, 
+			@RequestParam(value = "pageSize", required = false, defaultValue="20") Integer pageSize,
+			@RequestParam(value = "orderBy", required = false, defaultValue="product") String orderBy,
+			@RequestParam(value = "sortDescending", required = false, defaultValue="false") Boolean sortDescending
+			) throws InvalidArgumentsException, EntityRetrievalException {
 		
 		SearchRequest searchRequest = new SearchRequest();
-		
 		searchRequest.setSearchTerm(searchTerm);
+		
+		if(!StringUtils.isEmpty(certificationStatusesDelimited)) {
+			String[] certificationStatusArr = certificationStatusesDelimited.split(",");
+			if(certificationStatusArr != null && certificationStatusArr.length > 0) {
+				List<String> certificationStatuses = new ArrayList<String>();
+				Set<KeyValueModel> availableCertificationStatuses = searchMenuManager.getCertificationStatuses();
+				
+				for(int i = 0; i < certificationStatusArr.length; i++) {
+					String certStatusParam = certificationStatusArr[i].trim();
+					boolean found = false;
+					for(KeyValueModel currAvailableCertStatus : availableCertificationStatuses) {
+						if(currAvailableCertStatus.getName().equalsIgnoreCase(certStatusParam)) {
+							found = true;
+						}
+					}
+					if(!found) {
+						logger.error("Could not find certification status with value " + certStatusParam);
+						throw new InvalidArgumentsException("Could not find certification status with value " + certStatusParam);
+					} else {
+						certificationStatuses.add(certStatusParam);
+					}
+				}
+				searchRequest.setCertificationStatuses(certificationStatuses);
+			}
+		}
+		
+		if(!StringUtils.isEmpty(certificationEditionsDelimited)) {
+			String[] certificationEditionsArr = certificationEditionsDelimited.split(",");
+			if(certificationEditionsArr != null && certificationEditionsArr.length > 0) {
+				List<String> certificationEditions = new ArrayList<String>();
+				Set<KeyValueModel> availableCertificationEditions = searchMenuManager.getEditionNames(false);
+				
+				for(int i = 0; i < certificationEditionsArr.length; i++) {
+					String certEditionParam = certificationEditionsArr[i].trim();
+					boolean found = false;
+					for(KeyValueModel currAvailableEdition : availableCertificationEditions) {
+						if(currAvailableEdition.getName().equalsIgnoreCase(certEditionParam)) {
+							found = true;
+						}
+					}
+					if(!found) {
+						logger.error("Could not find certification edition with value " + certEditionParam);
+						throw new InvalidArgumentsException("Could not find certification edition with value " + certEditionParam);
+					} else {
+						certificationEditions.add(certEditionParam);
+					}
+				}
+				
+				searchRequest.setCertificationEditions(certificationEditions);
+			}
+		}
+		
+		if(!StringUtils.isEmpty(certificationCriteriaDelimited)) {
+			String[] certificationCriteriaArr = certificationCriteriaDelimited.split(",");
+			if(certificationCriteriaArr != null && certificationCriteriaArr.length > 0) {
+				List<String> certificationCriterion = new ArrayList<String>();
+				Set<DescriptiveModel> availableCriterion = searchMenuManager.getCertificationCriterionNumbers(false);
+				
+				for(int i = 0; i < certificationCriteriaArr.length; i++) {
+					String certCriteriaParam = certificationCriteriaArr[i].trim();
+					boolean found = false;
+					for(DescriptiveModel currAvailableCriteria : availableCriterion) {
+						if(currAvailableCriteria.getName().equalsIgnoreCase(certCriteriaParam)) {
+							found = true;
+						}
+					}
+					if(!found) {
+						logger.error("Could not find certification criterion with value " + certCriteriaParam);
+						throw new InvalidArgumentsException("Could not find certification criterion with value " + certCriteriaParam);
+					} else {
+						certificationCriterion.add(certCriteriaParam);
+					}
+				}
+				searchRequest.setCertificationCriteria(certificationCriterion);
+			}
+		}
+		
+		if(!StringUtils.isEmpty(cqmsDelimited)) {
+			String[] cqmsArr = cqmsDelimited.split(",");
+			if(cqmsArr != null && cqmsArr.length > 0) {
+				List<String> cqms = new ArrayList<String>();
+				Set<DescriptiveModel> availableCqms = searchMenuManager.getCQMCriterionNumbers(false);
+				
+				for(int i = 0; i < cqmsArr.length; i++) {
+					String cqmParam = cqmsArr[i].trim();
+					boolean found = false;
+					for(DescriptiveModel currAvailableCqm : availableCqms) {
+						if(currAvailableCqm.getName().equalsIgnoreCase(cqmParam)) {
+							found = true;
+						}
+					}
+					if(!found) {
+						logger.error("Could not find CQM with value " + cqmParam);
+						throw new InvalidArgumentsException("Could not find CQM with value " + cqmParam);
+					} else {
+						cqms.add(cqmParam.trim());
+					}
+				}
+				searchRequest.setCqms(cqms);
+			}
+		}
+		
+		if(!StringUtils.isEmpty(certificationBodiesDelimited)) {
+			String[] certificationBodiesArr = certificationBodiesDelimited.split(",");
+			if(certificationBodiesArr != null && certificationBodiesArr.length > 0) {
+				List<String> certBodies = new ArrayList<String>();
+				Set<KeyValueModel> availableCertBodies = searchMenuManager.getCertBodyNames();
+				
+				for(int i = 0; i < certificationBodiesArr.length; i++) {
+					String certBodyParam = certificationBodiesArr[i].trim();
+					boolean found = false;
+					for(KeyValueModel currAvailableCertBody : availableCertBodies) {
+						if(currAvailableCertBody.getName().equalsIgnoreCase(certBodyParam)) {
+							found = true;
+						}
+					}
+					if(!found) {
+						logger.error("Could not find certification body with value " + certBodyParam);
+						throw new InvalidArgumentsException("Could not find certification body with value " + certBodyParam);
+					} else {
+						certBodies.add(certBodyParam);
+					}
+				}
+				searchRequest.setCertificationBodies(certBodies);
+			}
+		}
+		
+		if(!StringUtils.isEmpty(surveillanceDelimited)) {
+			String[] surveillanceArr = surveillanceDelimited.split(",");
+			if(surveillanceArr != null && surveillanceArr.length > 0) {
+				Set<SurveillanceSearchOptions> surveillanceSearchOptions = new HashSet<SurveillanceSearchOptions>();
+				for(int i = 0; i < surveillanceArr.length; i++) {
+					String surveillanceParam = surveillanceArr[i].trim();
+					try {
+						SurveillanceSearchOptions searchOpt = SurveillanceSearchOptions.valueOf(surveillanceParam);
+						if(searchOpt != null) {
+							surveillanceSearchOptions.add(searchOpt);
+						} else {
+							logger.error("No surveillance search option for the string " + surveillanceParam);
+							throw new InvalidArgumentsException("No surveillance search option matches " + surveillanceParam);
+						}
+					} catch(Exception ex) {
+						logger.error("No surveillance search option for the string " + surveillanceParam, ex);
+						throw new InvalidArgumentsException("No surveillance search option matches " + surveillanceParam);
+					}
+				}
+				searchRequest.setSurveillance(surveillanceSearchOptions);
+			}
+		}
+		
+		searchRequest.setHasHadSurveillance(hasHadSurveillance);
+		if(!StringUtils.isEmpty(developer)) {
+			searchRequest.setDeveloper(developer.trim());
+		}
+		
+		if(!StringUtils.isEmpty(product)) {
+			searchRequest.setProduct(product.trim());
+		}
+		
+		if(!StringUtils.isEmpty(version)) {
+			searchRequest.setVersion(version.trim());
+		}
+		
+		if(!StringUtils.isEmpty(practiceType)) {
+			practiceType = practiceType.trim();
+			Set<KeyValueModel> availablePracticeTypes = searchMenuManager.getPracticeTypeNames();
+			boolean found = false;
+			for(KeyValueModel currAvailablePracticeType : availablePracticeTypes) {
+				if(currAvailablePracticeType.getName().equalsIgnoreCase(practiceType)) {
+					found = true;
+				}
+			}
+			
+			if(!found) {
+				logger.error("No practice type exists with name " + practiceType);
+				throw new InvalidArgumentsException("No practice type exists with name " + practiceType);
+			} else {
+				searchRequest.setPracticeType(practiceType);
+			}
+		}
+		
+		//check date formats
+		SimpleDateFormat format = new SimpleDateFormat(SearchRequest.CERTIFICATION_DATE_SEARCH_FORMAT);
+		if(!StringUtils.isEmpty(certificationDateStart)) {
+			certificationDateStart = certificationDateStart.trim();
+			try {
+				format.parse(certificationDateStart);
+			} catch(ParseException ex) {
+				logger.error("Could not parse " + certificationDateStart + " as date in the format " + SearchRequest.CERTIFICATION_DATE_SEARCH_FORMAT);
+				throw new InvalidArgumentsException("Certification Date format expected is " + SearchRequest.CERTIFICATION_DATE_SEARCH_FORMAT + " Cannot parse " + certificationDateStart);
+			}
+			searchRequest.setCertificationDateStart(certificationDateStart);
+		}
+		
+		if(!StringUtils.isEmpty(certificationDateEnd)) {
+			certificationDateEnd = certificationDateEnd.trim();
+			try {
+				format.parse(certificationDateEnd);
+			} catch(ParseException ex) {
+				logger.error("Could not parse " + certificationDateEnd + " as date in the format " + SearchRequest.CERTIFICATION_DATE_SEARCH_FORMAT);
+				throw new InvalidArgumentsException("Certification Date format expected is " + SearchRequest.CERTIFICATION_DATE_SEARCH_FORMAT + " Cannot parse " + certificationDateEnd);
+			}
+			searchRequest.setCertificationDateEnd(certificationDateEnd);
+		}
+
 		searchRequest.setPageNumber(pageNumber);
 		searchRequest.setPageSize(pageSize);
-		
-		if (orderBy != null){
-			searchRequest.setOrderBy(orderBy);
-		}
-		
-		if (sortDescending != null){
-			searchRequest.setSortDescending(sortDescending);
-		}
+		searchRequest.setOrderBy(orderBy.trim());
+		searchRequest.setSortDescending(sortDescending);
 		
 		return certifiedProductSearchManager.search(searchRequest);
 		

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/SearchViewController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/SearchViewController.java
@@ -279,10 +279,12 @@ public class SearchViewController {
 			+ "Any parameter that can accept multiple things (i.e. certificationStatuses) expects a comma-delimited list of those things (i.e. certificationStatuses=Active,Suspended). "
 			+ "Date parameters are required to be in the format " + SearchRequest.CERTIFICATION_DATE_SEARCH_FORMAT + ". ")
 	 @ApiImplicitParams({
-		    @ApiImplicitParam(name = "searchTerm", value = "CHPL ID, Developer Name, Product Name, ACB Certifiation ID", required = false, dataType = "string", paramType = "query"),
+		    @ApiImplicitParam(name = "searchTerm", value = "CHPL ID, Developer Name, Product Name, ONC-ACB Certification ID", required = false, dataType = "string", paramType = "query"),
 		    @ApiImplicitParam(name = "certificationStatuses", value = "A comma-separated list of certification statuses "
-		    		+ "(ex: \"Active,Retired,Withdrawn by Developer\")). Retired listings are excluded unless requested with this parameter.", required = false, dataType = "string", paramType = "query"),
-		    @ApiImplicitParam(name = "certificationEditions", value = "A comma-separated list of certification editions (ex: \"2014,2015\").", required = false, dataType = "string", paramType = "query"),
+		    		+ "(ex: \"Active,Retired,Withdrawn by Developer\")). Retired listings are excluded unless requested with this parameter."
+				      + " Defaults to \"Active,Suspended by ONC, Suspended by ONC-ACB\"", required = false, dataType = "string", paramType = "query"),
+		    @ApiImplicitParam(name = "certificationEditions", value = "A comma-separated list of certification editions (ex: \"2014,2015\")."
+				      + " Defaults to "\"2014,2015\"", required = false, dataType = "string", paramType = "query"),
 		    @ApiImplicitParam(name = "certificationCriteria", value = "A comma-separated list of certification criteria (ex: \"170.314 (a)(1),170.314 (a)(2)\").", 
 		    	required = false, dataType = "string", paramType = "query"),
 		    @ApiImplicitParam(name = "cqms", value = "A comma-separated list of cqms (ex: \"CMS2,CMS9\").", 
@@ -310,7 +312,7 @@ public class SearchViewController {
 				required = false, dataType = "string", paramType = "query"),
 		    @ApiImplicitParam(name = "pageSize", value = "Number of results to return used in concert with pageNumber. Defaults to 20.", 
 				required = false, dataType = "string", paramType = "query"),
-		    @ApiImplicitParam(name = "orderBy", value = "What to search by. Options are one of the following: " 
+		    @ApiImplicitParam(name = "orderBy", value = "What to order by. Options are one of the following: " 
 		    	+ "developer, product, version, certificationEdition, productClassification, certificationBody, "
 		    	+ "certificationDate, or practiceType. Defaults to product.",
 				required = false, dataType = "string", paramType = "query"),
@@ -321,8 +323,8 @@ public class SearchViewController {
 			produces={"application/json; charset=utf-8", "application/xml"})
 	public @ResponseBody SearchResponse simpleSearch(
 			@RequestParam(value = "searchTerm", required=false) String searchTerm, 
-			@RequestParam(value = "certificationStatuses", required = false) String certificationStatusesDelimited,
-			@RequestParam(value="certificationEditions", required=false) String certificationEditionsDelimited,
+			@RequestParam(value = "certificationStatuses", required = false, defaultValue="Active,Suspended by ONC,Suspended by ONC-ACB") String certificationStatusesDelimited,
+			@RequestParam(value="certificationEditions", required=false, defaultValue="2014,2015") String certificationEditionsDelimited,
 			@RequestParam(value="certificationCriteria", required=false) String certificationCriteriaDelimited,
 			@RequestParam(value="cqms", required=false) String cqmsDelimited,
 			@RequestParam(value="certificationBodies", required=false) String certificationBodiesDelimited,

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/web/controller/SearchViewControllerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/web/controller/SearchViewControllerTest.java
@@ -67,6 +67,37 @@ public class SearchViewControllerTest extends TestCase {
 		adminUser.getPermissions().add(new GrantedPermission("ROLE_ADMIN"));
 	}
 	
+	@Transactional 
+	@Test
+	public void test_basicSearch_allProducts() 
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException {
+
+		SearchResponse searchResponse = searchViewController.simpleSearch(null, null, null, null, null, null, null,
+				null, null, null, null, null, null, null, 0, 10, "developer", true);
+		assertNotNull(searchResponse);
+		assertNotNull(searchResponse.getRecordCount());
+		assertEquals(12, searchResponse.getRecordCount().intValue());
+		assertNotNull(searchResponse.getResults());
+		assertEquals(10, searchResponse.getResults().size());
+	}
+	
+	
+	@Transactional 
+	@Test
+	public void test_basicSearch_emptyStringsAllParameters() 
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException {
+
+		SearchResponse searchResponse = searchViewController.simpleSearch(" ", " ", " ", " ", " ", " ", " ",
+				null, "  ", "  ", "  ", " ", " ", " ", 0, 50, "developer", true);
+		assertNotNull(searchResponse);
+		assertNotNull(searchResponse.getRecordCount());
+		assertEquals(12, searchResponse.getRecordCount().intValue());
+		assertNotNull(searchResponse.getResults());
+		assertEquals(12, searchResponse.getResults().size());
+	}
+	
 	/** Description: Tests that the advancedSearch returns valid SearchResponse records when refined by cqms
 	 * 
 	 * Expected Result: Completes without error and returns some SearchResponse records
@@ -88,7 +119,54 @@ public class SearchViewControllerTest extends TestCase {
 		
 		SearchResponse searchResponse = new SearchResponse();
 		searchResponse = searchViewController.advancedSearch(searchFilters);
-		assertTrue("searchViewController.simpleSearch() should return a SearchResponse with records", searchResponse.getRecordCount() > 0);
+		assertTrue("searchViewController.advancedSearch() should return a SearchResponse with records", searchResponse.getRecordCount() > 0);
+		SecurityContextHolder.getContext().setAuthentication(null);
+	}
+	
+	@Transactional 
+	@Test
+	public void test_basicSearch_refineByCqms_CompletesWithoutError() 
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException {
+
+		SearchResponse searchResponse = searchViewController.simpleSearch(null, null, null, null, "0001", null, null,
+				null, null, null, null, null, null, null, 0, 50, "developer", true);
+		assertNotNull(searchResponse);
+		assertNotNull(searchResponse.getRecordCount());
+		assertEquals(1, searchResponse.getRecordCount().intValue());
+		assertNotNull(searchResponse.getResults());
+		assertEquals(1, searchResponse.getResults().size());
+	}
+	
+	@Transactional 
+	@Test
+	public void test_basicSearch_refineByMultipleCqms_CompletesWithoutError() 
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException {
+
+		SearchResponse searchResponse = searchViewController.simpleSearch(null, null, null, null, "0001, 0004", null, null,
+				null, null, null, null, null, null, null, 0, 50, "developer", true);
+		assertNotNull(searchResponse);
+		assertNotNull(searchResponse.getRecordCount());
+		assertEquals(1, searchResponse.getRecordCount().intValue());
+		assertNotNull(searchResponse.getResults());
+		assertEquals(1, searchResponse.getResults().size());
+	}
+	
+	@Transactional 
+	@Test
+	public void test_basicSearch_refineByBadCqms_CompletesWithError() 
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException {
+
+		boolean failed = false;
+		try {
+			searchViewController.simpleSearch(null, null, null, null, "BAD CQM", null, null,
+					null, null, null, null, null, null, null, 0, 50, "developer", true);
+		} catch(InvalidArgumentsException ex) {
+			failed = true;
+		}
+		assertTrue(failed);
 	}
 	
 	/** Description: Tests that the advancedSearch returns valid SearchResponse records when refined by certification criteria
@@ -100,7 +178,6 @@ public class SearchViewControllerTest extends TestCase {
 	public void test_advancedSearch_refineByCertificationCriteria_CompletesWithoutError() 
 			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
 			InvalidArgumentsException {
-		SecurityContextHolder.getContext().setAuthentication(adminUser);
 		SearchRequest searchFilters = new SearchRequest();
 		List<String> certificationCriteria = new ArrayList<String>();
 		certificationCriteria.add("170.315 (a)(1)");
@@ -114,6 +191,52 @@ public class SearchViewControllerTest extends TestCase {
 		SearchResponse searchResponse = new SearchResponse();
 		searchResponse = searchViewController.advancedSearch(searchFilters);
 		assertTrue("searchViewController.simpleSearch() should return a SearchResponse with records", searchResponse.getRecordCount() > 0);
+	}
+	
+	@Transactional 
+	@Test
+	public void test_basicSearch_refineByCertificationCriteria_CompletesWithoutError() 
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException {
+
+		SearchResponse searchResponse = searchViewController.simpleSearch(null, null, null, "170.315 (a)(1)", null, null, null,
+				null, null, null, null, null, null, null, 0, 50, "developer", true);
+		assertNotNull(searchResponse);
+		assertNotNull(searchResponse.getRecordCount());
+		assertEquals(1, searchResponse.getRecordCount().intValue());
+		assertNotNull(searchResponse.getResults());
+		assertEquals(1, searchResponse.getResults().size());
+	}
+	
+	@Transactional 
+	@Test
+	public void test_basicSearch_refineByMultipleCertificationCriteria_CompletesWithoutError() 
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException {
+
+		SearchResponse searchResponse = searchViewController.simpleSearch(null, null, null, "170.314 (a)(1), 170.314 (a)(2)", null, null, null,
+				null, null, null, null, null, null, null, 0, 50, "developer", true);
+		assertNotNull(searchResponse);
+		assertNotNull(searchResponse.getRecordCount());
+		assertEquals(1, searchResponse.getRecordCount().intValue());
+		assertNotNull(searchResponse.getResults());
+		assertEquals(1, searchResponse.getResults().size());
+	}
+	
+	@Transactional 
+	@Test
+	public void test_basicSearch_refineByBadCertificationCriteria_CompletesWithError() 
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException {
+
+		boolean failed = false;
+		try {
+			searchViewController.simpleSearch(null, null, null, "BAD CRITERIA", null, null, null,
+					null, null, null, null, null, null, null, 0, 50, "developer", true);
+		} catch(InvalidArgumentsException ex) {
+			failed = true;
+		}
+		assertTrue(failed);
 	}
 	
 	/** Description: Tests that the advancedSearch returns valid SearchResponse records when refined by certification criteria AND cqms
@@ -141,6 +264,126 @@ public class SearchViewControllerTest extends TestCase {
 		SearchResponse searchResponse = new SearchResponse();
 		searchResponse = searchViewController.advancedSearch(searchFilters);
 		assertTrue("searchViewController.simpleSearch() should return a SearchResponse with records", searchResponse.getRecordCount() > 0);
+	}
+	
+	@Transactional 
+	@Test
+	public void test_basicSearch_refineByCertificationCriteriaAndCqms_CompletesWithoutError() 
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException {
+
+		SearchResponse searchResponse = searchViewController.simpleSearch(null, null, null, "170.314 (a)(3)", "0001", null, null,
+				null, null, null, null, null, null, null, 0, 50, "developer", true);
+		assertNotNull(searchResponse);
+		assertNotNull(searchResponse.getRecordCount());
+		assertEquals(1, searchResponse.getRecordCount().intValue());
+		assertNotNull(searchResponse.getResults());
+		assertEquals(1, searchResponse.getResults().size());
+	}
+	
+	@Transactional 
+	@Test
+	public void test_basicSearch_emptyDeveloperName() 
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException {
+
+		SearchResponse searchResponse = searchViewController.simpleSearch(null, null, null, "170.314 (a)(3)", "0001", null, null,
+				null, "   ", null, null, null, null, null, 0, 50, "developer", true);
+		assertNotNull(searchResponse);
+		assertNotNull(searchResponse.getRecordCount());
+		assertEquals(1, searchResponse.getRecordCount().intValue());
+		assertNotNull(searchResponse.getResults());
+		assertEquals(1, searchResponse.getResults().size());
+	}
+	
+	@Transactional 
+	@Test
+	public void test_basicSearch_developerName() 
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException {
+
+		SearchResponse searchResponse = searchViewController.simpleSearch(null, null, null, null, null, null, null,
+				null, "Test Developer 1", null, null, null, null, null, 0, 50, "developer", true);
+		assertNotNull(searchResponse);
+		assertNotNull(searchResponse.getRecordCount());
+		assertEquals(5, searchResponse.getRecordCount().intValue());
+		assertNotNull(searchResponse.getResults());
+		assertEquals(5, searchResponse.getResults().size());
+	}
+
+	@Transactional 
+	@Test
+	public void test_basicSearch_badDeveloperName() 
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException {
+
+		SearchResponse searchResponse = searchViewController.simpleSearch(null, null, null, null, null, null, null,
+				null, "BOGUS DEVELOPER DOES NOT EXIST", null, null, null, null, null, 0, 50, "developer", true);
+		assertNotNull(searchResponse);
+		assertNotNull(searchResponse.getRecordCount());
+		assertEquals(0, searchResponse.getRecordCount().intValue());
+		assertNotNull(searchResponse.getResults());
+		assertEquals(0, searchResponse.getResults().size());
+	}
+	
+	@Transactional 
+	@Test
+	public void test_basicSearch_productName() 
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException {
+
+		SearchResponse searchResponse = searchViewController.simpleSearch(null, null, null, null, null, null, null,
+				null, null, "Test Product 1", null, null, null, null, 0, 50, "developer", true);
+		assertNotNull(searchResponse);
+		assertNotNull(searchResponse.getRecordCount());
+		assertEquals(3, searchResponse.getRecordCount().intValue());
+		assertNotNull(searchResponse.getResults());
+		assertEquals(3, searchResponse.getResults().size());
+	}
+	
+	@Transactional 
+	@Test
+	public void test_basicSearch_versionName() 
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException {
+
+		SearchResponse searchResponse = searchViewController.simpleSearch(null, null, null, null, null, null, null,
+				null, null, "Test Product 1", "1.0.0", null, null, null, 0, 50, "developer", true);
+		assertNotNull(searchResponse);
+		assertNotNull(searchResponse.getRecordCount());
+		assertEquals(1, searchResponse.getRecordCount().intValue());
+		assertNotNull(searchResponse.getResults());
+		assertEquals(1, searchResponse.getResults().size());
+	}
+	
+	@Transactional 
+	@Test
+	public void test_basicSearch_certificationBodyName() 
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException {
+
+		SearchResponse searchResponse = searchViewController.simpleSearch(null, null, null, null, null, "InfoGard", null,
+				null, null, null, null, null, null, null, 0, 50, "developer", true);
+		assertNotNull(searchResponse);
+		assertNotNull(searchResponse.getRecordCount());
+		assertEquals(4, searchResponse.getRecordCount().intValue());
+		assertNotNull(searchResponse.getResults());
+		assertEquals(4, searchResponse.getResults().size());
+	}
+	
+	@Transactional 
+	@Test
+	public void test_basicSearch_certificationBodyNames() 
+			throws EntityRetrievalException, JsonProcessingException, EntityCreationException,
+			InvalidArgumentsException {
+
+		SearchResponse searchResponse = searchViewController.simpleSearch(null, null, null, null, null, "InfoGard, CCHIT", null,
+				null, null, null, null, null, null, null, 0, 50, "developer", true);
+		assertNotNull(searchResponse);
+		assertNotNull(searchResponse.getRecordCount());
+		assertEquals(8, searchResponse.getRecordCount().intValue());
+		assertNotNull(searchResponse.getResults());
+		assertEquals(8, searchResponse.getResults().size());
 	}
 	
 	/** 
@@ -317,16 +560,21 @@ public class SearchViewControllerTest extends TestCase {
 		String orderBy = "developer";
 		Boolean sortDescending = true;
 		
-		SearchResponse resp = searchViewController.simpleSearch(searchTerm, pageNumber, pageSize, orderBy, sortDescending);
-		assertTrue("SearchResponse should have size > 0 but is " + resp.getResults().size(), resp.getResults().size() > 0);
-		Boolean hasNumMeaningfulUse = false;
-		for(CertifiedProductSearchResult result : resp.getResults()){
-			if(result.getNumMeaningfulUse() != null){
-				hasNumMeaningfulUse = true;
-				break;
+		try {
+			SearchResponse resp = searchViewController.simpleSearch(searchTerm, null, null, null, null, null, null,
+					null, null, null, null, null, null, null, pageNumber, pageSize, orderBy, sortDescending);
+			assertTrue("SearchResponse should have size > 0 but is " + resp.getResults().size(), resp.getResults().size() > 0);
+			Boolean hasNumMeaningfulUse = false;
+			for(CertifiedProductSearchResult result : resp.getResults()){
+				if(result.getNumMeaningfulUse() != null){
+					hasNumMeaningfulUse = true;
+					break;
+				}
 			}
+			assertTrue("SearchResponse should contain results with numMeaningfulUse.", hasNumMeaningfulUse);
+		} catch(InvalidArgumentsException ex) {
+			fail(ex.getMessage());
 		}
-	assertTrue("SearchResponse should contain results with numMeaningfulUse.", hasNumMeaningfulUse);
 	}
 	
 	/** 


### PR DESCRIPTION
Please look closely at the parameter documentation which is all the @ApiImplicitParam annotations. I am not sure that I got the defaults right on all of them or that they are all accurate descriptions of the behavior.  Mostly things like how we exclude Retired by default... are there other things like that?? Feel free to change any of them or just make a list for me and I will do it. 