### PR TITLE
OCD-1393: refactor caching to return Future

### DIFF
--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/caching/CacheReplacer.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/caching/CacheReplacer.java
@@ -3,6 +3,8 @@ package gov.healthit.chpl.caching;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import net.sf.ehcache.Cache;
@@ -10,6 +12,7 @@ import net.sf.ehcache.Element;
 
 @Component
 public class CacheReplacer {
+	private static final Logger logger = LogManager.getLogger(CacheReplacer.class);
 	
 	/** Removes all keys from the oldCache and puts all keys from the newCache into the oldCache
 	 * 
@@ -17,9 +20,14 @@ public class CacheReplacer {
 	 * @param newCache - the cache whose keys will replace the values in the old cache
 	 */
 	public static void replaceCache(Cache oldCache, Cache newCache){
+		logger.info("Replacing " + oldCache.getName() + " with " + newCache.getName());
 		List<Integer> keys = newCache.getKeys();
 		Map<Object, Element> objects = newCache.getAll(keys);
-		oldCache.removeAll();
-		oldCache.putAll(objects.values());
+		if(objects.size() > 0){
+			oldCache.removeAll();
+			oldCache.putAll(objects.values());
+		} else{
+			logger.info("Attempted to replace cache " + oldCache.getName() + " with an empty cache.");
+		}
 	}
 }

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/caching/CacheUpdater.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/caching/CacheUpdater.java
@@ -1,29 +1,35 @@
 package gov.healthit.chpl.caching;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.stereotype.Component;
 
+import net.sf.ehcache.CacheException;
 import net.sf.ehcache.CacheManager;
 
 @Component
 @Aspect
-public class CacheEvictor {
-	private static final Logger logger = LogManager.getLogger(CacheEvictor.class);
+public class CacheUpdater {
+	private static final Logger logger = LogManager.getLogger(CacheUpdater.class);
 	
 	@Autowired private CacheUtil cacheUtil;
 	@Autowired private PreFetchedCaches preFetchedCaches;
 	
 	@After("@annotation(ClearBasicSearch)")
 	@Async
-	public void evictPreFetchedBasicSearch(){
+	public Future<Boolean> updateBasicSearch() throws IllegalStateException, CacheException, ClassCastException, InterruptedException, ExecutionException{
 		CacheManager manager = cacheUtil.getMyCacheManager();
-		logger.debug("Evicted " + CacheNames.PRE_FETCHED_BASIC_SEARCH);
+		logger.info("Evicted " + CacheNames.PRE_FETCHED_BASIC_SEARCH);
 		preFetchedCaches.initializePreFetchedBasicSearch();
 		CacheReplacer.replaceCache(manager.getCache(CacheNames.BASIC_SEARCH), manager.getCache(CacheNames.PRE_FETCHED_BASIC_SEARCH));
+		return new AsyncResult<>(true);
 	}
 }


### PR DESCRIPTION
This allows the following unit test to pass consistently: CertifiedProductSearchManagerTest.testBasicSearchCache()

It was failing because the unit test would proceed with testing assertions while the CacheEvictor.evictPreFetchedBasicSearch() was still asynchronously executing in the background and on some developers' machines, the asynchonous method would finish in time for the assertions to pass while on others this would not be the case. I renamed CacheEvictor to CacheUpdater to be more specific to what's actually happening, and I added a Future object so that the unit test can wait for the asynchronous method to complete executing before making assertions.