### PR TITLE
OCD-1772: fix certification_ids/BADID not returning 404; remove spaces

### DIFF
--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/ActivityController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/ActivityController.java
@@ -112,7 +112,7 @@ public class ActivityController {
             notes = "Users can optionally specify 'start' and 'end' parameters to restrict the date range of the results. "
                     + "Only users calling this API with ROLE_ADMIN may set the 'showDeleted' flag to true and should "
                     + "do so if the certification body specified in the path has been deleted. ")
-    @RequestMapping(value = "/acbs/ {id}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
+    @RequestMapping(value = "/acbs/{id}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
     public List<ActivityEvent> activityForACBById(@PathVariable("id") Long id,
             @RequestParam(required = false) Long start, @RequestParam(required = false) Long end,
             @RequestParam(value = "showDeleted", required = false, defaultValue = "false") boolean showDeleted)
@@ -167,7 +167,7 @@ public class ActivityController {
     @ApiOperation(value = "Get auditable data for a specific announcement",
             notes = "Users can optionally specify 'start' and 'end' parameters to restrict the date range of the results. "
                     + "The default behavior is to return all activity for the specified announcement across all dates.")
-    @RequestMapping(value = "/announcements/ {id}", method = RequestMethod.GET,
+    @RequestMapping(value = "/announcements/{id}", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public List<ActivityEvent> activityForAnnouncementById(@PathVariable("id") Long id,
             @RequestParam(required = false) Long start, @RequestParam(required = false) Long end)
@@ -226,7 +226,7 @@ public class ActivityController {
             notes = "Users can optionally specify 'start' and 'end' parameters to restrict the date range of the results. "
                     + "Only users calling this API with ROLE_ADMIN may set the 'showDeleted' flag to true and should "
                     + "do so if the testing lab specified in the path has been deleted. ")
-    @RequestMapping(value = "/atls/ {id}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
+    @RequestMapping(value = "/atls/{id}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
     public List<ActivityEvent> activityForATLById(@PathVariable("id") Long id,
             @RequestParam(required = false) Long start, @RequestParam(required = false) Long end,
             @RequestParam(value = "showDeleted", required = false, defaultValue = "false") boolean showDeleted)
@@ -304,7 +304,7 @@ public class ActivityController {
     @ApiOperation(value = "Get auditable data for a specific certified product",
             notes = "Users can optionally specify 'start' and 'end' parameters to restrict the date range of the results. "
                     + "The default behavior is to return activity for the specified certified product across all dates.")
-    @RequestMapping(value = "/certified_products/ {id}", method = RequestMethod.GET,
+    @RequestMapping(value = "/certified_products/{id}", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public List<ActivityEvent> activityForCertifiedProductById(@PathVariable("id") Long id,
             @RequestParam(required = false) Long start, @RequestParam(required = false) Long end)
@@ -354,7 +354,7 @@ public class ActivityController {
     @ApiOperation(value = "Get auditable data for a specific certification",
             notes = "Users can optionally specify 'start' and 'end' parameters to restrict the date range of the results. "
                     + "The default behavior is to return activity for the specified certification across all dates.")
-    @RequestMapping(value = "/certifications/ {id}", method = RequestMethod.GET,
+    @RequestMapping(value = "/certifications/{id}", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public List<ActivityEvent> activityForCertificationById(@PathVariable("id") Long id,
             @RequestParam(required = false) Long start, @RequestParam(required = false) Long end)
@@ -404,7 +404,7 @@ public class ActivityController {
     @ApiOperation(value = "Get auditable data for a specific pending certified product",
             notes = "Users can optionally specify 'start' and 'end' parameters to restrict the date range of the results. "
                     + "The default behavior is to return activity for the specified pending certified product across all dates.")
-    @RequestMapping(value = "/pending_certified_products/ {id}", method = RequestMethod.GET,
+    @RequestMapping(value = "/pending_certified_products/{id}", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public List<ActivityEvent> activityForPendingCertifiedProductById(@PathVariable("id") Long id,
             @RequestParam(required = false) Long start, @RequestParam(required = false) Long end)
@@ -454,7 +454,7 @@ public class ActivityController {
     @ApiOperation(value = "Get auditable data for a specific product",
             notes = "Users can optionally specify 'start' and 'end' parameters to restrict the date range of the results. "
                     + "The default behavior is to return activity for the specified product across all dates.")
-    @RequestMapping(value = "/products/ {id}", method = RequestMethod.GET,
+    @RequestMapping(value = "/products/{id}", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public List<ActivityEvent> activityForProducts(@PathVariable("id") Long id,
             @RequestParam(required = false) Long start, @RequestParam(required = false) Long end)
@@ -503,7 +503,7 @@ public class ActivityController {
     @ApiOperation(value = "Get auditable data for a specific version",
             notes = "Users can optionally specify 'start' and 'end' parameters to restrict the date range of the results. "
                     + "The default behavior is to return activity for the specified version across all dates.")
-    @RequestMapping(value = "/versions/ {id}", method = RequestMethod.GET,
+    @RequestMapping(value = "/versions/{id}", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public List<ActivityEvent> activityForVersions(@PathVariable("id") Long id,
             @RequestParam(required = false) Long start, @RequestParam(required = false) Long end)
@@ -552,7 +552,7 @@ public class ActivityController {
     @ApiOperation(value = "Get auditable data about a specific CHPL user account",
             notes = "API users can optionally specify to only get activity a certain number of days into the past with the 'lastNDays' parameter. "
                     + "The default behavior is to return activity for the specified CHPL user across all dates.")
-    @RequestMapping(value = "/users/ {id}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
+    @RequestMapping(value = "/users/{id}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
     public List<ActivityEvent> activityForUsers(@PathVariable("id") Long id, @RequestParam(required = false) Long start,
             @RequestParam(required = false) Long end)
             throws JsonParseException, IOException, UserRetrievalException, ValidationException {
@@ -600,7 +600,7 @@ public class ActivityController {
     @ApiOperation(value = "Get auditable data for a specific developer",
             notes = "Users can optionally specify 'start' and 'end' parameters to restrict the date range of the results. "
                     + "The default behavior is to return activity for the specified developer across all dates.")
-    @RequestMapping(value = "/developers/ {id}", method = RequestMethod.GET,
+    @RequestMapping(value = "/developers/{id}", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public List<ActivityEvent> activityForDeveloperById(@PathVariable("id") Long id,
             @RequestParam(required = false) Long start, @RequestParam(required = false) Long end)
@@ -653,7 +653,7 @@ public class ActivityController {
             notes = "The authenticated user calling this method must have ROLE_ADMIN. "
                     + "Users can optionally specify 'start' and 'end' parameters to restrict the date range of the results. "
                     + "The default behavior is to return the specified user's activity across all dates.")
-    @RequestMapping(value = "/user_activities/ {id}", method = RequestMethod.GET,
+    @RequestMapping(value = "/user_activities/{id}", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public List<ActivityEvent> activityByUser(@PathVariable("id") Long id, @RequestParam(required = false) Long start,
             @RequestParam(required = false) Long end)

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/AnnouncementController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/AnnouncementController.java
@@ -66,7 +66,7 @@ public class AnnouncementController {
     }
 
     @ApiOperation(value = "Get a specific announcement.")
-    @RequestMapping(value = "/ {announcementId}", method = RequestMethod.GET,
+    @RequestMapping(value = "/{announcementId}", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public @ResponseBody Announcement getAnnouncementById(@PathVariable("announcementId") Long announcementId)
             throws EntityRetrievalException {
@@ -123,7 +123,7 @@ public class AnnouncementController {
 
     @ApiOperation(value = "Delete an existing announcement.",
             notes = "Only CHPL users with ROLE_ADMIN are able to delete announcements.")
-    @RequestMapping(value = "/ {announcementId}/delete", method = RequestMethod.POST,
+    @RequestMapping(value = "/{announcementId}/delete", method = RequestMethod.POST,
             produces = "application/json; charset=utf-8")
     public String deleteAnnouncement(@PathVariable("announcementId") Long announcementId)
             throws JsonProcessingException, EntityCreationException, EntityRetrievalException, UserRetrievalException {

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/ApiKeyController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/ApiKeyController.java
@@ -138,7 +138,7 @@ public class ApiKeyController {
 
     @ApiOperation(value = "View the calls made by a specific API key.",
             notes = "This service is only available to CHPL users with ROLE_ADMIN.")
-    @RequestMapping(value = "/activity/ {apiKey}", method = RequestMethod.POST,
+    @RequestMapping(value = "/activity/{apiKey}", method = RequestMethod.POST,
             consumes = MediaType.APPLICATION_JSON_VALUE, produces = "application/json; charset=utf-8")
     public List<ApiKeyActivity> listActivityByKey(@PathVariable("apiKey") String apiKey,
             @RequestParam(value = "pageNumber", required = false) Integer pageNumber,

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/CertificationBodyController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/CertificationBodyController.java
@@ -87,7 +87,7 @@ public class CertificationBodyController {
     @ApiOperation(value = "Get details about a specific certification body (ACB).",
             notes = "The logged in user must either have ROLE_ADMIN or have ROLE_ACB_ADMIN or ROLE_ACB_STAFF "
                     + " for the ACB with the provided ID.")
-    @RequestMapping(value = "/ {acbId}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
+    @RequestMapping(value = "/{acbId}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
     public @ResponseBody CertificationBody getAcbById(@PathVariable("acbId") Long acbId)
             throws EntityRetrievalException {
         CertificationBodyDTO acb = acbManager.getById(acbId);
@@ -158,7 +158,7 @@ public class CertificationBodyController {
     }
 
     @ApiOperation(value = "Delete an ACB.", notes = "The logged in user must have ROLE_ADMIN.")
-    @RequestMapping(value = "/ {acbId}/delete", method = RequestMethod.POST,
+    @RequestMapping(value = "/{acbId}/delete", method = RequestMethod.POST,
             produces = "application/json; charset=utf-8")
     public String deleteAcb(@PathVariable("acbId") Long acbId)
             throws JsonProcessingException, EntityCreationException, EntityRetrievalException, UserRetrievalException {
@@ -171,7 +171,7 @@ public class CertificationBodyController {
     @ApiOperation(value = "Restore a deleted ACB.",
             notes = "ACBs are unique in the CHPL in that they can be restored after a delete."
                     + " The logged in user must have ROLE_ADMIN.")
-    @RequestMapping(value = "/ {acbId}/undelete", method = RequestMethod.POST,
+    @RequestMapping(value = "/{acbId}/undelete", method = RequestMethod.POST,
             produces = "application/json; charset=utf-8")
     public String undeleteAcb(@PathVariable("acbId") Long acbId)
             throws JsonProcessingException, EntityCreationException, EntityRetrievalException, UserRetrievalException {
@@ -214,7 +214,7 @@ public class CertificationBodyController {
             notes = "The logged in user must have ROLE_ADMIN or ROLE_ACB_ADMIN and have administrative authority on the "
                     + " specified ACB. The user specified in the request will have all authorities "
                     + " removed that are associated with the specified ACB.")
-    @RequestMapping(value = "{acbId}/remove_user/ {userId}", method = RequestMethod.POST,
+    @RequestMapping(value = "{acbId}/remove_user/{userId}", method = RequestMethod.POST,
             consumes = MediaType.APPLICATION_JSON_VALUE, produces = "application/json; charset=utf-8")
     public String deleteUserFromAcb(@PathVariable Long acbId, @PathVariable Long userId)
             throws UserRetrievalException, EntityRetrievalException, InvalidArgumentsException {
@@ -235,7 +235,7 @@ public class CertificationBodyController {
     @ApiOperation(value = "List users with permissions on a specified ACB.",
             notes = "The logged in user must have ROLE_ADMIN or have administrative or read authority on the "
                     + " specified ACB.")
-    @RequestMapping(value = "/ {acbId}/users", method = RequestMethod.GET,
+    @RequestMapping(value = "/{acbId}/users", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public @ResponseBody PermittedUserResults getUsers(@PathVariable("acbId") Long acbId)
             throws InvalidArgumentsException, EntityRetrievalException {

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/CertificationIdController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/CertificationIdController.java
@@ -118,7 +118,7 @@ public class CertificationIdController {
     // **********************************************************************************************************
     // getCertificationId
     //
-    // Mapping: / {certificationId}
+    // Mapping: /{certificationId}
     // Params: Boolean includeCriteria
     // Params: Boolean includeCqms
     //
@@ -130,14 +130,14 @@ public class CertificationIdController {
     // **********************************************************************************************************
     @ApiOperation(value = "Get information about a specific EHR Certification ID.",
             notes = "Retrieves detailed information about a specific EHR Certification ID including the list of products that make it up.")
-    @RequestMapping(value = "/ {certificationId}", method = RequestMethod.GET, produces = {
+    @RequestMapping(value = "/{certificationId}", method = RequestMethod.GET, produces = {
             MediaType.APPLICATION_JSON_VALUE
     })
     public @ResponseBody CertificationIdLookupResults getCertificationId(
             @PathVariable("certificationId") String certificationId,
             @RequestParam(required = false, defaultValue = "false") Boolean includeCriteria,
             @RequestParam(required = false, defaultValue = "false") Boolean includeCqms)
-            throws InvalidArgumentsException, CertificationIdException {
+            throws InvalidArgumentsException, EntityRetrievalException, CertificationIdException {
         return this.findCertificationIdByCertificationId(certificationId, includeCriteria, includeCqms);
     }
 
@@ -184,7 +184,8 @@ public class CertificationIdController {
     //
     // **********************************************************************************************************
     private CertificationIdLookupResults findCertificationIdByCertificationId(String certificationId,
-            Boolean includeCriteria, Boolean includeCqms) throws InvalidArgumentsException, CertificationIdException {
+            Boolean includeCriteria, Boolean includeCqms) 
+                    throws InvalidArgumentsException, EntityRetrievalException, CertificationIdException {
         CertificationIdLookupResults results = new CertificationIdLookupResults();
         try {
             // Lookup the Cert ID
@@ -233,7 +234,7 @@ public class CertificationIdController {
             }
 
         } catch (final EntityRetrievalException ex) {
-            throw new CertificationIdException("Unable to lookup Certification ID " + certificationId + ".");
+            throw new EntityRetrievalException("Unable to lookup Certification ID " + certificationId + ".");
         }
 
         return results;

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/CertifiedProductController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/CertifiedProductController.java
@@ -139,7 +139,7 @@ public class CertifiedProductController {
 
     @ApiOperation(value = "Get all details for a specified certified product.",
             notes = "Returns all information in the CHPL related to the specified certified product.")
-    @RequestMapping(value = "/ {certifiedProductId}/details", method = RequestMethod.GET,
+    @RequestMapping(value = "/{certifiedProductId}/details", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public @ResponseBody CertifiedProductSearchDetails getCertifiedProductById(
             @PathVariable("certifiedProductId") Long certifiedProductId) throws EntityRetrievalException {
@@ -154,7 +154,7 @@ public class CertifiedProductController {
 
     @ApiOperation(value = "Get the ICS family tree for the specified certified product.",
             notes = "Returns all member of the family tree conected to the specified certified product.")
-    @RequestMapping(value = "/ {certifiedProductId}/ics_relationships", method = RequestMethod.GET,
+    @RequestMapping(value = "/{certifiedProductId}/ics_relationships", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public @ResponseBody List<IcsFamilyTreeNode> getIcsFamilyTreeById(
             @PathVariable("certifiedProductId") Long certifiedProductId) throws EntityRetrievalException {
@@ -296,7 +296,7 @@ public class CertifiedProductController {
     }
 
     @ApiOperation(value = "List a specific pending certified product.", notes = "")
-    @RequestMapping(value = "/pending/ {pcpId}", method = RequestMethod.GET,
+    @RequestMapping(value = "/pending/{pcpId}", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public @ResponseBody PendingCertifiedProductDetails getPendingCertifiedProductById(
             @PathVariable("pcpId") Long pcpId) throws EntityRetrievalException, EntityNotFoundException,
@@ -309,7 +309,7 @@ public class CertifiedProductController {
     @ApiOperation(value = "Reject a pending certified product.",
             notes = "Essentially deletes a pending certified product. ROLE_ACB_ADMIN, ROLE_ACB_STAFF "
                     + " and administrative authority on the ACB is required.")
-    @RequestMapping(value = "/pending/ {pcpId}/reject", method = RequestMethod.POST,
+    @RequestMapping(value = "/pending/{pcpId}/reject", method = RequestMethod.POST,
             produces = "application/json; charset=utf-8")
     public @ResponseBody String rejectPendingCertifiedProduct(@PathVariable("pcpId") Long id)
             throws EntityRetrievalException, JsonProcessingException, EntityCreationException, EntityNotFoundException,

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/CorrectiveActionPlanController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/CorrectiveActionPlanController.java
@@ -80,9 +80,9 @@ public class CorrectiveActionPlanController {
     @ApiOperation(value = "DEPRECATED. Use surveillance API methods.<br/> Get corrective action plan details.",
             notes = "Get all of the information about a specific corrective action plan. These details "
                     + " include the presence and associated id's of any uploaded supporting "
-                    + " documentation but not the contents of those documents. Use /documentation/ {capDocId} to "
+                    + " documentation but not the contents of those documents. Use /documentation/{capDocId} to "
                     + " view the files.")
-    @RequestMapping(value = "/ {capId}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
+    @RequestMapping(value = "/{capId}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
     @Deprecated
     public @ResponseBody CorrectiveActionPlanDetails getCorrectiveActionPlanById(@PathVariable("capId") Long capId)
             throws EntityRetrievalException {
@@ -91,7 +91,7 @@ public class CorrectiveActionPlanController {
 
     @ApiOperation(value = "DEPRECATED. Use surveillance API methods.<br/> Download CAP supporting documentation.",
             notes = "Download a specific file that was previously uploaded to a corrective action plan.")
-    @RequestMapping(value = "/documentation/ {capDocId}", method = RequestMethod.GET)
+    @RequestMapping(value = "/documentation/{capDocId}", method = RequestMethod.GET)
     @Deprecated
     public void getCorrectiveActionPlanDocumentationById(@PathVariable("capDocId") Long capDocId,
             HttpServletResponse response) throws EntityRetrievalException, IOException {
@@ -284,7 +284,7 @@ public class CorrectiveActionPlanController {
                     + " documentation to an existing CAP. The logged in user uploading the file "
                     + " must have either ROLE_ADMIN or ROLE_ACB_ADMIN and administrative "
                     + " authority on the associated ACB.")
-    @RequestMapping(value = "/ {capId}/documentation", method = RequestMethod.POST,
+    @RequestMapping(value = "/{capId}/documentation", method = RequestMethod.POST,
             produces = "application/json; charset=utf-8")
     @Deprecated
     public @ResponseBody String upload(@PathVariable("capId") Long correctiveActionPlanId,
@@ -410,7 +410,7 @@ public class CorrectiveActionPlanController {
     @ApiOperation(value = "DEPRECATED. Use surveillance API methods.<br/>Delete a corrective action plan.",
             notes = "The logged in user" + " must have either ROLE_ADMIN or ROLE_ACB_ADMIN and administrative "
                     + " authority on the associated ACB.")
-    @RequestMapping(value = "/ {planId}/delete", method = RequestMethod.POST,
+    @RequestMapping(value = "/{planId}/delete", method = RequestMethod.POST,
             produces = "application/json; charset=utf-8")
     @Deprecated
     public String deleteAcb(@PathVariable("planId") Long planId) throws JsonProcessingException,
@@ -450,7 +450,7 @@ public class CorrectiveActionPlanController {
             value = "DEPRECATED. Use surveillance API methods.<br/>Remove documentation from a corrective action plan.",
             notes = "The logged in user" + " must have either ROLE_ADMIN or ROLE_ACB_ADMIN and administrative "
                     + " authority on the associated ACB.")
-    @RequestMapping(value = "/documentation/ {docId}/delete", method = RequestMethod.POST,
+    @RequestMapping(value = "/documentation/{docId}/delete", method = RequestMethod.POST,
             produces = "application/json; charset=utf-8")
     @Deprecated
     public String deleteDocumentationById(@PathVariable("docId") Long docId) throws JsonProcessingException,

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/DeveloperController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/DeveloperController.java
@@ -80,7 +80,7 @@ public class DeveloperController {
     }
 
     @ApiOperation(value = "Get information about a specific developer.", notes = "")
-    @RequestMapping(value = "/ {developerId}", method = RequestMethod.GET,
+    @RequestMapping(value = "/{developerId}", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public @ResponseBody Developer getDeveloperById(@PathVariable("developerId") Long developerId)
             throws EntityRetrievalException {

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/NotificationController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/NotificationController.java
@@ -62,7 +62,7 @@ public class NotificationController {
     }
 
     @ApiOperation(value = "Update the email address and associated subscriptions of the recipient specified.")
-    @RequestMapping(value = "/recipients/ {recipientId}/update", method = RequestMethod.POST,
+    @RequestMapping(value = "/recipients/{recipientId}/update", method = RequestMethod.POST,
             produces = "application/json; charset=utf-8")
     public @ResponseBody Recipient updateRecipient(@PathVariable("recipientId") Long recipientId,
             @RequestBody Recipient updatedRecipient) throws InvalidArgumentsException, EntityRetrievalException {
@@ -201,7 +201,7 @@ public class NotificationController {
     }
 
     @ApiOperation(value = "Remove subscription(s) for a recipient.")
-    @RequestMapping(value = "/recipients/ {recipientId}/delete", method = RequestMethod.POST,
+    @RequestMapping(value = "/recipients/{recipientId}/delete", method = RequestMethod.POST,
             produces = "application/json; charset=utf-8")
     public @ResponseBody void deleteRecipient(@PathVariable("recipientId") Long recipientId)
             throws EntityRetrievalException, InvalidArgumentsException {

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/ProductController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/ProductController.java
@@ -81,7 +81,7 @@ public class ProductController {
     }
 
     @ApiOperation(value = "Get information about a specific product.", notes = "")
-    @RequestMapping(value = "/ {productId}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
+    @RequestMapping(value = "/{productId}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
     public @ResponseBody Product getProductById(@PathVariable("productId") Long productId)
             throws EntityRetrievalException {
         ProductDTO product = productManager.getById(productId);
@@ -94,7 +94,7 @@ public class ProductController {
     }
 
     @ApiOperation(value = "Get all listings owned by the specified product.", notes = "")
-    @RequestMapping(value = "/ {productId}/listings", method = RequestMethod.GET,
+    @RequestMapping(value = "/{productId}/listings", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public @ResponseBody List<CertifiedProduct> getListingsForProduct(@PathVariable("productId") Long productId)
             throws EntityRetrievalException {
@@ -213,7 +213,7 @@ public class ProductController {
     @ApiOperation(
             value = "Split a product - some versions stay with the existing product and some versions are moved to a new product.",
             notes = "The logged in user must have ROLE_ADMIN, ROLE_ACB_ADMIN, or ROLE_ACB_STAFF. ")
-    @RequestMapping(value = "/ {productId}/split", method = RequestMethod.POST,
+    @RequestMapping(value = "/{productId}/split", method = RequestMethod.POST,
             consumes = MediaType.APPLICATION_JSON_VALUE, produces = "application/json; charset=utf-8")
     public ResponseEntity<SplitProductResponse> splitProduct(@PathVariable("productId") Long productId,
             @RequestBody(required = true) SplitProductsRequest splitRequest) throws EntityCreationException,

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/ProductVersionController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/ProductVersionController.java
@@ -62,7 +62,7 @@ public class ProductVersionController {
     }
 
     @ApiOperation(value = "Get information about a specific version.", notes = "")
-    @RequestMapping(value = "/ {versionId}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
+    @RequestMapping(value = "/{versionId}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
     public @ResponseBody ProductVersion getProductVersionById(@PathVariable("versionId") Long versionId)
             throws EntityRetrievalException {
         ProductVersionDTO version = pvManager.getById(versionId);

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/SearchViewController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/SearchViewController.java
@@ -877,7 +877,7 @@ public class SearchViewController {
     }
 
     @ApiOperation(value = "Get all search options in the CHPL",
-            notes = "This returns all of the other /data/ {something} results in one single response.")
+            notes = "This returns all of the other /data/{something} results in one single response.")
     @RequestMapping(value = "/data/search_options", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public @ResponseBody PopulateSearchOptions getPopulateSearchData(

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/SurveillanceController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/SurveillanceController.java
@@ -127,7 +127,7 @@ public class SurveillanceController implements MessageSourceAware {
 
     @ApiOperation(value = "Download nonconformity supporting documentation.",
             notes = "Download a specific file that was previously uploaded to a surveillance nonconformity.")
-    @RequestMapping(value = "/document/ {documentId}", method = RequestMethod.GET)
+    @RequestMapping(value = "/document/{documentId}", method = RequestMethod.GET)
     public void streamDocumentContents(@PathVariable("documentId") Long documentId, HttpServletResponse response)
             throws EntityRetrievalException, IOException {
         SurveillanceNonconformityDocument doc = survManager.getDocumentById(documentId, true);
@@ -231,7 +231,7 @@ public class SurveillanceController implements MessageSourceAware {
                     + " documentation to an existing nonconformity. The logged in user uploading the file "
                     + " must have either ROLE_ADMIN or ROLE_ACB_ADMIN and administrative "
                     + " authority on the associated ACB.")
-    @RequestMapping(value = "/ {surveillanceId}/nonconformity/ {nonconformityId}/document/create",
+    @RequestMapping(value = "/{surveillanceId}/nonconformity/{nonconformityId}/document/create",
             method = RequestMethod.POST, produces = "application/json; charset=utf-8")
     public @ResponseBody String uploadNonconformityDocument(@PathVariable("surveillanceId") Long surveillanceId,
             @PathVariable("nonconformityId") Long nonconformityId, @RequestParam("file") MultipartFile file)
@@ -329,7 +329,7 @@ public class SurveillanceController implements MessageSourceAware {
             notes = "Deletes an existing surveillance activity, surveilled requirements, and any applicable non-conformities "
                     + "in the system. " + "ROLE_ACB_ADMIN or ROLE_ACB_STAFF "
                     + " and administrative authority on the ACB associated with the certified product is required.")
-    @RequestMapping(value = "/ {surveillanceId}/delete", method = RequestMethod.POST,
+    @RequestMapping(value = "/{surveillanceId}/delete", method = RequestMethod.POST,
             produces = "application/json; charset=utf-8")
     public synchronized @ResponseBody ResponseEntity<String> deleteSurveillance(
             @PathVariable(value = "surveillanceId") Long surveillanceId)
@@ -380,7 +380,7 @@ public class SurveillanceController implements MessageSourceAware {
     @ApiOperation(value = "Remove documentation from a nonconformity.",
             notes = "The logged in user" + " must have either ROLE_ADMIN or ROLE_ACB_ADMIN and administrative "
                     + " authority on the associated ACB.")
-    @RequestMapping(value = "/ {surveillanceId}/document/ {docId}/delete", method = RequestMethod.POST,
+    @RequestMapping(value = "/{surveillanceId}/document/{docId}/delete", method = RequestMethod.POST,
             produces = "application/json; charset=utf-8")
     public String deleteNonconformityDocument(@PathVariable("surveillanceId") Long surveillanceId,
             @PathVariable("docId") Long docId) throws JsonProcessingException, EntityCreationException,
@@ -416,7 +416,7 @@ public class SurveillanceController implements MessageSourceAware {
     }
 
     @ApiOperation(value = "Reject (effectively delete) a pending surveillance item.")
-    @RequestMapping(value = "/pending/ {pendingSurvId}/reject", method = RequestMethod.POST,
+    @RequestMapping(value = "/pending/{pendingSurvId}/reject", method = RequestMethod.POST,
             produces = "application/json; charset=utf-8")
     public @ResponseBody String deletePendingSurveillance(@PathVariable("pendingSurvId") Long id)
             throws EntityNotFoundException, AccessDeniedException, ObjectMissingValidationException,

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/TestingLabController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/TestingLabController.java
@@ -92,7 +92,7 @@ public class TestingLabController {
     @ApiOperation(value = "Get details about a specific testing lab (ATL).",
             notes = "The logged in user must have ROLE_ADMIN or have either read or"
                     + "administrative authority on the testing lab with the ID specified.")
-    @RequestMapping(value = "/ {atlId}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
+    @RequestMapping(value = "/{atlId}", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
     public @ResponseBody TestingLab getAtlById(@PathVariable("atlId") Long atlId) throws EntityRetrievalException {
         TestingLabDTO atl = atlManager.getById(atlId);
 
@@ -168,7 +168,7 @@ public class TestingLabController {
     }
 
     @ApiOperation(value = "Delete an ATL.", notes = "The logged in user must have ROLE_ADMIN.")
-    @RequestMapping(value = "/ {atlId}/delete", method = RequestMethod.POST,
+    @RequestMapping(value = "/{atlId}/delete", method = RequestMethod.POST,
             produces = "application/json; charset=utf-8")
     public String deleteAtl(@PathVariable("atlId") Long atlId)
             throws JsonProcessingException, EntityCreationException, EntityRetrievalException, UserRetrievalException {
@@ -182,7 +182,7 @@ public class TestingLabController {
     @ApiOperation(value = "Restore a deleted ATL.",
             notes = "ATLs are unique in the CHPL in that they can be restored after a delete."
                     + " The logged in user must have ROLE_ADMIN.")
-    @RequestMapping(value = "/ {atlId}/undelete", method = RequestMethod.POST,
+    @RequestMapping(value = "/{atlId}/undelete", method = RequestMethod.POST,
             produces = "application/json; charset=utf-8")
     public String undeleteAtl(@PathVariable("atlId") Long atlId)
             throws JsonProcessingException, EntityCreationException, EntityRetrievalException {
@@ -226,7 +226,7 @@ public class TestingLabController {
             notes = "The logged in user must have ROLE_ADMIN or ROLE_ATL_ADMIN and have administrative authority on the "
                     + " specified ATL. The user specified in the request will have all authorities "
                     + " removed that are associated with the specified ATL.")
-    @RequestMapping(value = "{atlId}/remove_user/ {userId}", method = RequestMethod.POST,
+    @RequestMapping(value = "{atlId}/remove_user/{userId}", method = RequestMethod.POST,
             consumes = MediaType.APPLICATION_JSON_VALUE, produces = "application/json; charset=utf-8")
     public String deleteUserFromAtl(@PathVariable Long atlId, @PathVariable Long userId)
             throws UserRetrievalException, EntityRetrievalException, InvalidArgumentsException {
@@ -247,7 +247,7 @@ public class TestingLabController {
     @ApiOperation(value = "List users with permissions on a specified ATL.",
             notes = "The logged in user must have ROLE_ADMIN or have administrative or read authority on the "
                     + " specified ATL.")
-    @RequestMapping(value = "/ {atlId}/users", method = RequestMethod.GET,
+    @RequestMapping(value = "/{atlId}/users", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public @ResponseBody PermittedUserResults getUsers(@PathVariable("atlId") Long atlId)
             throws InvalidArgumentsException, EntityRetrievalException {

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/UserManagementController.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/web/controller/UserManagementController.java
@@ -282,7 +282,7 @@ public class UserManagementController {
     @ApiOperation(value = "Delete a user.",
             notes = "Deletes a user account and all associated authorities on ACBs and ATLs. "
                     + "The logged in user must have ROLE_ADMIN.")
-    @RequestMapping(value = "/ {userId}/delete", method = RequestMethod.POST,
+    @RequestMapping(value = "/{userId}/delete", method = RequestMethod.POST,
             produces = "application/json; charset=utf-8")
     public String deleteUser(@PathVariable("userId") Long userId)
             throws UserRetrievalException, UserManagementException, UserPermissionRetrievalException,
@@ -426,7 +426,7 @@ public class UserManagementController {
     @ApiOperation(value = "View a specific user's details.",
             notes = "The logged in user must either be the user in the parameters, have ROLE_ADMIN, or "
                     + "have ROLE_ACB_ADMIN.")
-    @RequestMapping(value = "/ {userName}/details", method = RequestMethod.GET,
+    @RequestMapping(value = "/{userName}/details", method = RequestMethod.GET,
             produces = "application/json; charset=utf-8")
     public @ResponseBody UserInfoJSONObject getUser(@PathVariable("userName") String userName)
             throws UserRetrievalException {


### PR DESCRIPTION
Noticed that all the URLs that had /{something in brackets} had an extra space added between the / and { due to a find/replace done during checkstyle fixes. It wasn't affecting the URLs being called but I figured I'd take out the space anyway since it shouldn't be there. The actual fix for the certification_ids/BADID call is in CertificationIdController and it just needed to return an EntityRetrievalException since that is the one that causes us to send back a 404 status code.