### PR TITLE
OCD-1890: Change tests to support different numbers of upload templates

### DIFF
--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/dao/impl/UploadTemplateVersionDAOTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/dao/impl/UploadTemplateVersionDAOTest.java
@@ -35,13 +35,13 @@ import junit.framework.TestCase;
 @DatabaseSetup("classpath:data/testData.xml")
 public class UploadTemplateVersionDAOTest extends TestCase {
 	private static JWTAuthenticatedUser adminUser;
-	
+
 	@Autowired private UploadTemplateVersionDAO templateDao;;
-	
+
 	@Rule
     @Autowired
     public UnitTestRules cacheInvalidationRule;
-		
+
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		adminUser = new JWTAuthenticatedUser();
@@ -51,15 +51,15 @@ public class UploadTemplateVersionDAOTest extends TestCase {
 		adminUser.setSubjectName("admin");
 		adminUser.getPermissions().add(new GrantedPermission("ROLE_ADMIN"));
 	}
-	
+
 	@Test
 	@Transactional
-	public void findAll() {
+	public void canFindAll() {
 		List<UploadTemplateVersionDTO> allTemplates = templateDao.findAll();
 		assertNotNull(allTemplates);
-		assertEquals(2, allTemplates.size());
+		assertTrue(allTemplates.size() >= 2);
 	}
-	
+
 	@Test
 	@Transactional
 	public void findById() throws EntityRetrievalException {

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/manager/impl/SearchMenuManagerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/manager/impl/SearchMenuManagerTest.java
@@ -639,13 +639,13 @@ public class SearchMenuManagerTest {
             assertTrue(testStandard.getYear().equals("2014") || testStandard.getYear().equals("2015"));
         }
     }
-    
+
     @Transactional
     @Rollback(true)
     @Test
     public void getUploadTemplateVersions() {
         Set<UploadTemplateVersion> templateVersions = searchMenuManager.getUploadTemplateVersions();
         assertNotNull(templateVersions);
-        assertEquals(2, templateVersions.size());
+        assertTrue(templateVersions.size() >= 2);
     }
 }


### PR DESCRIPTION
All we can know about the upload templates is that there will be at least two
of them, up until the time 2014 is retired completely. For the DAO and Manager
tests, we just need to assert that there are at least two templates.