### PR TITLE
OCD-1977: add info to stat email about dates

### DIFF
--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/app/statistics/SummaryStatistics.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/app/statistics/SummaryStatistics.java
@@ -206,9 +206,13 @@ public class SummaryStatistics {
     }
 
     private String createHtmlMessage(Statistics stats, List<File> files) {
-        Calendar calendarCounter = Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.UTC));
+        Calendar currDateCal = Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.UTC));
+        Calendar endDateCal = Calendar.getInstance(TimeZone.getTimeZone(ZoneOffset.UTC));
+        endDateCal.setTime(endDate);
         StringBuilder emailMessage = new StringBuilder();
-        emailMessage.append("Date: " + calendarCounter.getTime());
+        emailMessage.append("Email body has current statistics as of " + currDateCal.getTime());
+        emailMessage.append("<br/>");
+        emailMessage.append("Email attachment has weekly statistics ending " + endDateCal.getTime());
         emailMessage.append(
                 "<h4>Total # of Unique Developers (Regardless of Edition) -  " + stats.getTotalDevelopers() + "</h4>");
         emailMessage.append("<ul><li>Total # of Developers with Active 2014 Listings - "


### PR DESCRIPTION
Jennifer approved of the text change in the email.

Was: 
Date: Mon Jan 15 17:13:37 UTC 2018

Now:
Email body has current statistics as of Mon Jan 15 15:52:49 EST 2018
Email attachment has weekly statistics ending Sun Jan 14 19:00:00 EST 2018

I will merge back into development after patching it into staging.