### PR TITLE
App logging

### DIFF
--- a/PENDING_PENDING_RELEASE_NOTES.md
+++ b/PENDING_PENDING_RELEASE_NOTES.md
@@ -5,6 +5,7 @@ _Date TBD_
 ### New Features
 * Converted "Downloadable Resource File" generation application to Quartz Job
   * Updated API endpoints to not return "System jobs" in regular GET call
+* Logs for individually run apps will now show up in separate files under the logs directory.
 
 ### Bugs Fixed
 * Save and display test tool name and test tool version for criteria 170.314 (c)(1)

--- a/chpl/chpl-service/generateChartDataStatistics.sh
+++ b/chpl/chpl-service/generateChartDataStatistics.sh
@@ -5,20 +5,12 @@
 # 15 5 * * * cd /some/directory/chpl-api/chpl/chpl-service && ./generateChartDataStatistics.sh
 # This will run it at 0515 UTC, which (depending on DST) is 0015 EST
 
-# create timestamp and filename
-TIMESTAMP=$(date "+%Y.%m.%d-%H.%M.%S")
-log=logs/log.generateChartDataStatistics.$TIMESTAMP.txt
-
 # deal with spaces in filenames by saving off the default file separator (including spaces)
 # and using a different one for this application
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
-# put header info into log, then output application info into log file
-echo "Generate Statistics Date for Charts at: " $TIMESTAMP >> $log
-echo "####################################" >> $log
-java -Xmx800m -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.chartdata.ChartData >&1 >> $log
-echo "####################################" >> $log
+java -Xmx800m -Dchpl.home=/opt/chpl -Dchpl.appName=generateChartDataStatistics -Dlog4j.configurationFile=log4j2-app.xml -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.chartdata.ChartData
 
 # restore filename delimiters
 IFS=$SAVEIFS

--- a/chpl/chpl-service/generateDailySEDDetailsDownload.sh
+++ b/chpl/chpl-service/generateDailySEDDetailsDownload.sh
@@ -5,12 +5,4 @@
 # 15 5 * * * cd /some/directory/chpl-api/chpl/chpl-service && ./generateDailySEDDetailsDownload.sh
 # This will run it at 0515 UTC, which (depending on DST) is 0015 EST
 
-# create timestamp and filename
-TIMESTAMP=$(date "+%Y.%m.%d-%H.%M.%S")
-log=logs/log.generateSEDDetailsDownload.$TIMESTAMP.txt
-
-# put header info into log, then output application info into log file
-echo "SED Details generation at: " $TIMESTAMP >> $log
-echo "####################################" >> $log
-java -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.resource.G3Sed2015ResourceCreatorApp 2>&1 >> $log
-echo "####################################" >> $log
+java -Dchpl.home=/opt/chpl -Dchpl.appName=generateDailySEDDetailsDownload -Dlog4j.configurationFile=log4j2-app.xml -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.resource.G3Sed2015ResourceCreatorApp

--- a/chpl/chpl-service/generateDailySurveillanceOversightReport.sh
+++ b/chpl/chpl-service/generateDailySurveillanceOversightReport.sh
@@ -5,20 +5,12 @@
 # 15 5 * * * cd /some/directory/chpl-api/chpl/chpl-service && ./generateDailySurveillanceOversightReport.sh
 # This will run it at 0515 UTC, which (depending on DST) is 0015 EST
 
-# create timestamp and filename
-TIMESTAMP=$(date "+%Y.%m.%d-%H.%M.%S")
-log=logs/log.generateDailySurveillanceOversightReport.$TIMESTAMP.txt
-
 # deal with spaces in filenames by saving off the default file separator (including spaces)
 # and using a different one for this application
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
-# put header info into log, then output application info into log file
-echo "XML generation at: " $TIMESTAMP >> $log
-echo "####################################" >> $log
-java -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.SurveillanceOversightReportDailyApp 2>&1 >> $log
-echo "####################################" >> $log
+java -Dchpl.home=/opt/chpl -Dchpl.appName=generateDailySurveillanceOversightReport -Dlog4j.configurationFile=log4j2-app.xml -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.SurveillanceOversightReportDailyApp
 
 # restore filename delimiters
 IFS=$SAVEIFS

--- a/chpl/chpl-service/generateQuestionableActivityReport.sh
+++ b/chpl/chpl-service/generateQuestionableActivityReport.sh
@@ -5,10 +5,6 @@
 # 15 5 * * 1 cd /some/directory/chpl-api/chpl/chpl-service && ./generateQuestionableActivityReport.sh
 # This will run it at 0515 UTC, which (depending on DST) is 0015 EST
 
-# create timestamp and filename
-TIMESTAMP=$(date "+%Y.%m.%d-%H.%M.%S")
-log=logs/log.generateQuestionableActivityReport.$TIMESTAMP.txt
-
 # deal with spaces in filenames by saving off the default file separator (including spaces)
 # and using a different one for this application
 SAVEIFS=$IFS
@@ -19,13 +15,9 @@ STARTDATE=$(date -d "7 days ago" '+%F')
 # get end date as current day
 ENDDATE=$(date "+%F")
 
-# put header info into log, then output application info into log file
-echo "Generate questionable activity email at: " $TIMESTAMP >> $log
-echo "####################################" >> $log
 # QuestionableActivityReport application takes two parameters: startDate and endDate. 
 # The dates have this format: yyyy-mm-dd
-java -Xmx800m -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.questionableActivity.QuestionableActivityReportApp $STARTDATE $ENDDATE 2>&1 >> $log
-echo "####################################" >> $log
+java -Xmx800m -Dchpl.home=/opt/chpl -Dchpl.appName=generateQuestionableActivityReport -Dlog4j.configurationFile=log4j2-app.xml -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.questionableActivity.QuestionableActivityReportApp $STARTDATE $ENDDATE
 
 # restore filename delimiters
 IFS=$SAVEIFS

--- a/chpl/chpl-service/generateSummaryEmail.sh
+++ b/chpl/chpl-service/generateSummaryEmail.sh
@@ -5,10 +5,6 @@
 # 15 5 * * * cd /some/directory/chpl-api/chpl/chpl-service && ./generateXml.sh
 # This will run it at 0515 UTC, which (depending on DST) is 0015 EST
 
-# create timestamp and filename
-TIMESTAMP=$(date "+%Y.%m.%d-%H.%M.%S")
-log=logs/log.generateSummaryEmail.$TIMESTAMP.txt
-
 # deal with spaces in filenames by saving off the default file separator (including spaces)
 # and using a different one for this application
 SAVEIFS=$IFS
@@ -27,12 +23,7 @@ done
 # get current time as formatted timestamp to input as command-line argument
 ENDDATE=$(date "+%F")
 
-# put header info into log, then output application info into log file
-echo "Generate summary email at: " $TIMESTAMP >> $log
-echo "####################################" >> $log
-# ParseActivities application takes three parameters: startDate, endDate, numDaysInPeriod. The dates have this format: yyyy-mm-dd
-java -Xmx800m -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.statistics.SummaryStatistics $STARTDATE $ENDDATE 7 2>&1 >> $log
-echo "####################################" >> $log
+java -Xmx800m -Dchpl.home=/opt/chpl -Dchpl.appName=generateSummaryEmail -Dlog4j.configurationFile=log4j2-app.xml -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.statistics.SummaryStatistics $STARTDATE $ENDDATE 7
 
 # restore filename delimiters
 IFS=$SAVEIFS

--- a/chpl/chpl-service/generateSummaryEmailNoCsv.sh
+++ b/chpl/chpl-service/generateSummaryEmailNoCsv.sh
@@ -5,10 +5,6 @@
 # 15 5 * * * cd /some/directory/chpl-api/chpl/chpl-service && ./generateXml.sh
 # This will run it at 0515 UTC, which (depending on DST) is 0015 EST
 
-# create timestamp and filename
-TIMESTAMP=$(date "+%Y.%m.%d-%H.%M.%S")
-log=logs/log.generateSummaryEmail.$TIMESTAMP.txt
-
 # deal with spaces in filenames by saving off the default file separator (including spaces)
 # and using a different one for this application
 SAVEIFS=$IFS
@@ -27,12 +23,8 @@ done
 # get current time as formatted timestamp to input as command-line argument
 ENDDATE=$(date "+%F")
 
-# put header info into log, then output application info into log file
-echo "Generate summary email at: " $TIMESTAMP >> $log
-echo "####################################" >> $log
-# ParseActivities application takes three parameters: startDate, endDate, numDaysInPeriod. The dates have this format: yyyy-mm-dd
-java -Xmx800m -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.statistics.SummaryStatistics $STARTDATE $ENDDATE 7 false 2>&1 >> $log
-echo "####################################" >> $log
+# GenerateSummaryEmail application takes three parameters: startDate, endDate, numDaysInPeriod. The dates have this format: yyyy-mm-dd
+java -Xmx800m -Dchpl.home=/opt/chpl -Dchpl.appName=generateSummaryEmailNoCsv -Dlog4j.configurationFile=log4j2-app.xml -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.statistics.SummaryStatistics $STARTDATE $ENDDATE 7 false
 
 # restore filename delimiters
 IFS=$SAVEIFS

--- a/chpl/chpl-service/generateSurveillanceResources.sh
+++ b/chpl/chpl-service/generateSurveillanceResources.sh
@@ -5,20 +5,12 @@
 # 15 5 * * * cd /some/directory/chpl-api/chpl/chpl-service && ./generateSurveillanceResources.sh
 # This will run it at 0515 UTC, which (depending on DST) is 0015 EST
 
-# create timestamp and filename
-TIMESTAMP=$(date "+%Y.%m.%d-%H.%M.%S")
-log=logs/log.generateSurveillanceResources.$TIMESTAMP.txt
-
 # deal with spaces in filenames by saving off the default file separator (including spaces)
 # and using a different one for this application
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
-# put header info into log, then output application info into log file
-echo "XML generation at: " $TIMESTAMP >> $log
-echo "####################################" >> $log
-java -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.resource.SurveillanceResourceCreatorApp 2>&1 >> $log
-echo "####################################" >> $log
+java -Dchpl.home=/opt/chpl -Dchpl.appName=generateSurveillanceResources -Dlog4j.configurationFile=log4j2-app.xml -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.resource.SurveillanceResourceCreatorApp
 
 # restore filename delimiters
 IFS=$SAVEIFS

--- a/chpl/chpl-service/generateWeeklyInvalidInheritanceReport.sh
+++ b/chpl/chpl-service/generateWeeklyInvalidInheritanceReport.sh
@@ -5,20 +5,12 @@
 # 15 5 * * * cd /some/directory/chpl-api/chpl/chpl-service && ./generateWeeklyInvalidInheritanceReport.sh
 # This will run it at 0515 UTC, which (depending on DST) is 0015 EST
 
-# create timestamp and filename
-TIMESTAMP=$(date "+%Y.%m.%d-%H.%M.%S")
-log=logs/log.generateWeeklyInvalidInheritanceReport.$TIMESTAMP.txt
-
 # deal with spaces in filenames by saving off the default file separator (including spaces)
 # and using a different one for this application
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
-# put header info into log, then output application info into log file
-echo "XML generation at: " $TIMESTAMP >> $log
-echo "####################################" >> $log
-java -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.InheritanceReportWeeklyApp 2>&1 >> $log
-echo "####################################" >> $log
+java -Dchpl.home=/opt/chpl -Dchpl.appName=generateWeeklyInvalidInheritanceReport -Dlog4j.configurationFile=log4j2-app.xml -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.InheritanceReportWeeklyApp
 
 # restore filename delimiters
 IFS=$SAVEIFS

--- a/chpl/chpl-service/generateWeeklySurveillanceOversightReport.sh
+++ b/chpl/chpl-service/generateWeeklySurveillanceOversightReport.sh
@@ -5,20 +5,12 @@
 # 15 5 * * * cd /some/directory/chpl-api/chpl/chpl-service && ./generateWeeklySurveillanceOversightReport.sh
 # This will run it at 0515 UTC, which (depending on DST) is 0015 EST
 
-# create timestamp and filename
-TIMESTAMP=$(date "+%Y.%m.%d-%H.%M.%S")
-log=logs/log.generateWeeklySurveillanceOversightReport.$TIMESTAMP.txt
-
 # deal with spaces in filenames by saving off the default file separator (including spaces)
 # and using a different one for this application
 SAVEIFS=$IFS
 IFS=$(echo -en "\n\b")
 
-# put header info into log, then output application info into log file
-echo "XML generation at: " $TIMESTAMP >> $log
-echo "####################################" >> $log
-java -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.SurveillanceOversightReportWeeklyApp 2>&1 >> $log
-echo "####################################" >> $log
+java -Dchpl.home=/opt/chpl -Dchpl.appName=generateWeeklySurveillanceOversightReport -Dlog4j.configurationFile=log4j2-app.xml -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.app.SurveillanceOversightReportWeeklyApp
 
 # restore filename delimiters
 IFS=$SAVEIFS

--- a/chpl/chpl-service/runScheduler.sh
+++ b/chpl/chpl-service/runScheduler.sh
@@ -1,12 +1,4 @@
 #!/bin/bash
 (set -o igncr) 2>/dev/null && set -o igncr; # this comment is required to trick cygwin into dealing with windows vs. linux EOL characters
 
-# create timestamp and filename
-TIMESTAMP=$(date "+%Y.%m.%d-%H.%M.%S")
-log=logs/log.runScheduler.$TIMESTAMP.txt
-
-# put header info into log, then output application info into log file
-echo "Starting Scheduler at: " $TIMESTAMP >> $log
-echo "####################################" >> $log
-java -Xmx800m -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.scheduler.ChplScheduler >&1 >> $log
-echo "####################################" >> $log
+java -Xmx800m -Dchpl.home=/opt/chpl -Dchpl.appName=runScheduler -Dlog4j.configurationFile=log4j2-app.xml -cp target/chpl-service-jar-with-dependencies.jar gov.healthit.chpl.scheduler.ChplScheduler

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/app/resource/CertifiedProductDownloadableResourceCreatorApp.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/app/resource/CertifiedProductDownloadableResourceCreatorApp.java
@@ -32,10 +32,7 @@ public abstract class CertifiedProductDownloadableResourceCreatorApp extends Dow
     @Override
     protected void runJob(final String[] args) throws Exception {
         Date start = new Date();
-        String edition = "";
         try {
-            edition = args[0].trim();
-
             List<CertifiedProductDetailsDTO> listings = getRelevantListings();
 
             List<Future<CertifiedProductSearchDetails>> futures = getCertifiedProductSearchDetailsFutures(listings);
@@ -52,7 +49,7 @@ public abstract class CertifiedProductDownloadableResourceCreatorApp extends Dow
             LOGGER.error(e);
         }
         Date end = new Date();
-        LOGGER.info("Time to create file(s) for " + edition + " edition: "
+        LOGGER.info("Time to create file(s): "
                 + (end.getTime() - start.getTime()) / 1000 + " seconds");
     }
 

--- a/chpl/chpl-service/src/main/resources-dev/log4j2-app.xml
+++ b/chpl/chpl-service/src/main/resources-dev/log4j2-app.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configuration>
+<Configuration status="warn" monitorInterval="300"
+    name="CHPL-App-DEV" packages="">
+    <Properties>
+        <Property name="logDir">${sys:chpl.home}/logs</Property>
+        <Property name="appName">${sys:chpl.appName}</Property>
+    </Properties>
+    <Appenders>
+        <RollingFile name="FILE" fileName="${logDir}/chplservice.log"
+            filePattern="${logDir}/${appName}-%d{yyyyMMdd}.log">
+            <PatternLayout>
+                <Pattern>%d %p %C %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <TimeBasedTriggeringPolicy
+                    interval="1" modulate="true" />
+            </Policies>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.jose4j" level="WARN" additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Logger name="org.hibernate" level="INFO" additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Logger name="org.springframework" level="INFO"
+            additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Logger name="gov.healthit.chpl" level="INFO" additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+                <Logger name="gov.healthit.chpl.app" level="INFO"
+            additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Logger name="gov.healthit.chpl.auth.SendMailUtil" level="INFO"
+            additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Logger name="org.quartz" level="INFO"
+            additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Root level="INFO">
+            <AppenderRef ref="FILE" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/chpl/chpl-service/src/main/resources-dev/log4j2-app.xml
+++ b/chpl/chpl-service/src/main/resources-dev/log4j2-app.xml
@@ -7,7 +7,7 @@
         <Property name="appName">${sys:chpl.appName}</Property>
     </Properties>
     <Appenders>
-        <RollingFile name="FILE" fileName="${logDir}/chplservice.log"
+        <RollingFile name="FILE" fileName="${logDir}/${appName}.log"
             filePattern="${logDir}/${appName}-%d{yyyyMMdd}.log">
             <PatternLayout>
                 <Pattern>%d %p %C %m%n</Pattern>

--- a/chpl/chpl-service/src/main/resources-production/log4j2-app.xml
+++ b/chpl/chpl-service/src/main/resources-production/log4j2-app.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configuration>
+<Configuration status="warn" monitorInterval="300"
+    name="CHPL-App-PRD" packages="">
+    <Properties>
+        <Property name="logDir">${sys:chpl.home}/logs</Property>
+        <Property name="appName">${sys:chpl.appName}</Property>
+    </Properties>
+    <Appenders>
+        <RollingFile name="FILE" fileName="${logDir}/chplservice.log"
+            filePattern="${logDir}/${appName}-%d{yyyyMMdd}.log">
+            <PatternLayout>
+                <Pattern>%d %p %C %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <TimeBasedTriggeringPolicy
+                    interval="1" modulate="true" />
+            </Policies>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.jose4j" level="ERROR" additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Logger name="org.hibernate" level="ERROR" additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Logger name="org.springframework" level="ERROR"
+            additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Logger name="gov.healthit.chpl" level="INFO" additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Root level="WARN">
+            <AppenderRef ref="FILE" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/chpl/chpl-service/src/main/resources-production/log4j2-app.xml
+++ b/chpl/chpl-service/src/main/resources-production/log4j2-app.xml
@@ -7,7 +7,7 @@
         <Property name="appName">${sys:chpl.appName}</Property>
     </Properties>
     <Appenders>
-        <RollingFile name="FILE" fileName="${logDir}/chplservice.log"
+        <RollingFile name="FILE" fileName="${logDir}/${appName}.log"
             filePattern="${logDir}/${appName}-%d{yyyyMMdd}.log">
             <PatternLayout>
                 <Pattern>%d %p %C %m%n</Pattern>

--- a/chpl/chpl-service/src/main/resources-staging/log4j2-app.xml
+++ b/chpl/chpl-service/src/main/resources-staging/log4j2-app.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configuration>
+<Configuration status="warn" monitorInterval="300"
+    name="CHPL-App-STG" packages="">
+    <Properties>
+        <Property name="logDir">${sys:chpl.home}/logs</Property>
+        <Property name="appName">${sys:chpl.appName}</Property>
+    </Properties>
+    <Appenders>
+        <RollingFile name="FILE" fileName="${logDir}/chplservice.log"
+            filePattern="${logDir}/${appName}-%d{yyyyMMdd}.log">
+            <PatternLayout>
+                <Pattern>%d %p %C %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <TimeBasedTriggeringPolicy
+                    interval="1" modulate="true" />
+            </Policies>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.jose4j" level="ERROR" additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Logger name="org.hibernate" level="ERROR" additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Logger name="org.springframework" level="ERROR"
+            additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Logger name="gov.healthit.chpl" level="INFO" additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Root level="WARN">
+            <AppenderRef ref="FILE" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/chpl/chpl-service/src/main/resources-staging/log4j2-app.xml
+++ b/chpl/chpl-service/src/main/resources-staging/log4j2-app.xml
@@ -7,7 +7,7 @@
         <Property name="appName">${sys:chpl.appName}</Property>
     </Properties>
     <Appenders>
-        <RollingFile name="FILE" fileName="${logDir}/chplservice.log"
+        <RollingFile name="FILE" fileName="${logDir}/${appName}.log"
             filePattern="${logDir}/${appName}-%d{yyyyMMdd}.log">
             <PatternLayout>
                 <Pattern>%d %p %C %m%n</Pattern>

--- a/chpl/chpl-service/src/main/resources/log4j2-app.xml
+++ b/chpl/chpl-service/src/main/resources/log4j2-app.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Configuration>
+<Configuration status="warn" monitorInterval="300"
+    name="CHPL-App" packages="">
+    <Properties>
+        <Property name="logDir">.</Property>
+        <Property name="appName">${sys:chpl.appName}</Property>
+    </Properties>
+    <Appenders>
+        <RollingFile name="FILE" fileName="${logDir}/chplservice.log"
+            filePattern="${logDir}/${appName}-%d{yyyyMMdd}.log">
+            <PatternLayout>
+                <Pattern>%d %p %C %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <TimeBasedTriggeringPolicy
+                    interval="1" modulate="true" />
+            </Policies>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.jose4j" level="WARN" additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Logger name="org.hibernate" level="WARN" additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Logger name="org.springframework" level="INFO"
+            additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Logger name="gov.healthit.chpl" level="INFO" additivity="false">
+            <AppenderRef ref="FILE" />
+        </Logger>
+        <Root level="INFO">
+            <AppenderRef ref="FILE" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/chpl/chpl-service/src/main/resources/log4j2-app.xml
+++ b/chpl/chpl-service/src/main/resources/log4j2-app.xml
@@ -7,7 +7,7 @@
         <Property name="appName">${sys:chpl.appName}</Property>
     </Properties>
     <Appenders>
-        <RollingFile name="FILE" fileName="${logDir}/chplservice.log"
+        <RollingFile name="FILE" fileName="${logDir}/${appName}.log"
             filePattern="${logDir}/${appName}-%d{yyyyMMdd}.log">
             <PatternLayout>
                 <Pattern>%d %p %C %m%n</Pattern>


### PR DESCRIPTION
Logs for apps were appearing all mushed together in chplservice.log but now they will appear in chpl.home/chpl.appName.log (configured in the -D arguments of each .sh file) and each apps logfile will be rolled over daily. The app-level logging is also controlled by a different log4j configuration to allow for different logging levels than we might want in the tomcat environment. This came up as an issue while trying to determine what happened to the missing summary statistics email and trying to find the appropriate logs.