### PR TITLE
Quartz Job definition tweaks

### DIFF
--- a/chpl/chpl-resources/src/main/resources-dev/jobs.xml
+++ b/chpl/chpl-resources/src/main/resources-dev/jobs.xml
@@ -51,7 +51,7 @@
                 <job-name>downloadFileJob2015</job-name>
                 <job-group>systemJobs</job-group>
                 <misfire-instruction>MISFIRE_INSTRUCTION_DO_NOTHING</misfire-instruction>
-                <cron-expression>0 30 4 * * ?</cron-expression> <!-- At 0430 UTC every day -->
+                <cron-expression>0 0 5 * * ?</cron-expression> <!-- At 0500 UTC every day -->
             </cron>
         </trigger>
 
@@ -76,7 +76,7 @@
                 <job-name>downloadFileJob2014</job-name>
                 <job-group>systemJobs</job-group>
                 <misfire-instruction>MISFIRE_INSTRUCTION_DO_NOTHING</misfire-instruction>
-                <cron-expression>0 35 4 * * ?</cron-expression> <!-- At 0435 UTC every day -->
+                <cron-expression>0 30 6 * * ?</cron-expression> <!-- At 0630 UTC every day -->
             </cron>
         </trigger>
 
@@ -121,7 +121,7 @@
                 <job-name>g3Sed2015DownloadFileJob</job-name>
                 <job-group>systemJobs</job-group>
                 <misfire-instruction>MISFIRE_INSTRUCTION_DO_NOTHING</misfire-instruction>
-                <cron-expression>0 50 4 * * ?</cron-expression> <!-- At 0450 UTC every day -->
+                <cron-expression>0 30 3 * * ?</cron-expression> <!-- At 0330 UTC every day -->
             </cron>
         </trigger>
 
@@ -141,7 +141,7 @@
                 <job-name>surveillanceDownloadFileJob</job-name>
                 <job-group>systemJobs</job-group>
                 <misfire-instruction>MISFIRE_INSTRUCTION_DO_NOTHING</misfire-instruction>
-                <cron-expression>0 55 4 * * ?</cron-expression> <!-- At 0455 UTC every day -->
+                <cron-expression>0 15 4 * * ?</cron-expression> <!-- At 0415 UTC every day -->
             </cron>
         </trigger>
 
@@ -446,25 +446,7 @@
                 </entry>
             </job-data-map>
         </job>
-        <!-- Chart data creator -->
-        <job>
-            <name>chartDataCreator</name>
-            <group>systemJobs</group>
-            <description>Generates the chart data</description>
-            <job-class>gov.healthit.chpl.scheduler.job.chartdata.ChartDataCreatorJob</job-class>
-            <durability>true</durability>
-            <recover>false</recover>
-        </job>
-        <trigger>
-            <cron>
-                <name>generateChartData</name>
-                <group>chartDataCreatorTrigger</group>
-                <job-name>chartDataCreator</job-name>
-                <job-group>systemJobs</job-group>
-                <misfire-instruction>MISFIRE_INSTRUCTION_DO_NOTHING</misfire-instruction>
-                <cron-expression>0 30 02 * * ?</cron-expression> <!-- At 0230 UTC every day -->
-            </cron>
-        </trigger>
+
         <!-- Questionable Activity data emailer -->
         <job>
             <name>Questionable Activity Report</name>
@@ -572,7 +554,27 @@
                 <cron-expression>0 0 11 ? * WED</cron-expression>
             </cron>
         </trigger>
-        
+
+        <!-- Chart data creator -->
+        <job>
+            <name>chartDataCreator</name>
+            <group>systemJobs</group>
+            <description>Generates the chart data</description>
+            <job-class>gov.healthit.chpl.scheduler.job.chartdata.ChartDataCreatorJob</job-class>
+            <durability>true</durability>
+            <recover>false</recover>
+        </job>
+        <trigger>
+            <cron>
+                <name>generateChartData</name>
+                <group>chartDataCreatorTrigger</group>
+                <job-name>chartDataCreator</job-name>
+                <job-group>systemJobs</job-group>
+                <misfire-instruction>MISFIRE_INSTRUCTION_DO_NOTHING</misfire-instruction>
+                <cron-expression>0 30 02 * * ?</cron-expression> <!-- At 0230 UTC every day -->
+            </cron>
+        </trigger>
+
         <!-- API Key Delete Warning Job -->
         <job>
             <name>apiKeyDeleteWarningEmailJob</name>
@@ -589,10 +591,10 @@
                 <job-name>apiKeyDeleteWarningEmailJob</job-name>
                 <job-group>systemJobs</job-group>
                 <misfire-instruction>MISFIRE_INSTRUCTION_FIRE_ONCE_NOW</misfire-instruction>
-                <cron-expression>0 0 4 1/1 * ? *</cron-expression> <!-- At 0400 UTC on every day -->
+                <cron-expression>0 0 4 1/1 * ? *</cron-expression> <!-- At 0400 UTC every day -->
             </cron>
         </trigger>
-        
+
         <!-- API Key Delete Job -->
         <job>
             <name>apiKeyDeleteJob</name>
@@ -609,9 +611,10 @@
                 <job-name>apiKeyDeleteJob</job-name>
                 <job-group>systemJobs</job-group>
                 <misfire-instruction>MISFIRE_INSTRUCTION_FIRE_ONCE_NOW</misfire-instruction>
-                <cron-expression>0 30 4 1/1 * ? *</cron-expression> <!-- At 0430 UTC on every day -->
+                <cron-expression>0 30 4 1/1 * ? *</cron-expression> <!-- At 0430 UTC every day -->
             </cron>
         </trigger>
+
         <!-- Job used to trigger interruptions of other jobs -->
         <job>
             <name>interruptJob</name>

--- a/chpl/chpl-resources/src/main/resources-production/jobs.xml
+++ b/chpl/chpl-resources/src/main/resources-production/jobs.xml
@@ -9,6 +9,7 @@
         <delete-triggers-in-group>interruptJob</delete-triggers-in-group>
     </pre-processing-commands>
     <schedule>
+        <!-- Delete from here to "DELETE END MARKER" after PROD push -->
         <!-- Job used to trigger interruptions of other jobs -->
         <job>
             <name>interruptJob</name>
@@ -18,5 +19,58 @@
             <durability>true</durability>
             <recover>false</recover>
         </job>
+
+        <!-- Update triggers to run in serial -->
+        <trigger>
+            <cron>
+                <name>generate2015</name>
+                <group>downloadFileTrigger</group>
+                <job-name>downloadFileJob2015</job-name>
+                <job-group>systemJobs</job-group>
+                <misfire-instruction>MISFIRE_INSTRUCTION_DO_NOTHING</misfire-instruction>
+                <cron-expression>0 0 5 * * ?</cron-expression> <!-- At 0500 UTC every day -->
+            </cron>
+        </trigger>
+        <trigger>
+            <cron>
+                <name>generate2014</name>
+                <group>downloadFileTrigger</group>
+                <job-name>downloadFileJob2014</job-name>
+                <job-group>systemJobs</job-group>
+                <misfire-instruction>MISFIRE_INSTRUCTION_DO_NOTHING</misfire-instruction>
+                <cron-expression>0 30 6 * * ?</cron-expression> <!-- At 0630 UTC every day -->
+            </cron>
+        </trigger>
+        <trigger>
+            <cron>
+                <name>generate2011</name>
+                <group>downloadFileTrigger</group>
+                <job-name>downloadFileJob2011</job-name>
+                <job-group>systemJobs</job-group>
+                <misfire-instruction>MISFIRE_INSTRUCTION_FIRE_ONCE_NOW</misfire-instruction>
+                <cron-expression>0 45 4 ? JAN,APR,JUL,OCT 7#1</cron-expression> <!-- At 0445 UTC on the first Saturday of the quarter -->
+            </cron>
+        </trigger>
+        <trigger>
+            <cron>
+                <name>g3Sed2015DownloadFileJob</name>
+                <group>downloadFileTrigger</group>
+                <job-name>g3Sed2015DownloadFileJob</job-name>
+                <job-group>systemJobs</job-group>
+                <misfire-instruction>MISFIRE_INSTRUCTION_DO_NOTHING</misfire-instruction>
+                <cron-expression>0 30 3 * * ?</cron-expression> <!-- At 0330 UTC every day -->
+            </cron>
+        </trigger>
+        <trigger>
+            <cron>
+                <name>surveillanceDownloadFileJob</name>
+                <group>downloadFileTrigger</group>
+                <job-name>surveillanceDownloadFileJob</job-name>
+                <job-group>systemJobs</job-group>
+                <misfire-instruction>MISFIRE_INSTRUCTION_DO_NOTHING</misfire-instruction>
+                <cron-expression>0 15 4 * * ?</cron-expression> <!-- At 0415 UTC every day -->
+            </cron>
+        </trigger>
+        <!-- DELETE END MARKER -->
     </schedule>
 </job-scheduling-data>

--- a/chpl/chpl-resources/src/main/resources-staging/jobs.xml
+++ b/chpl/chpl-resources/src/main/resources-staging/jobs.xml
@@ -446,6 +446,7 @@
                 </entry>
             </job-data-map>
         </job>
+
         <!-- Questionable Activity data emailer -->
         <job>
             <name>Questionable Activity Report</name>
@@ -461,7 +462,7 @@
                 </entry>
                 <entry>
                     <key>frequency</key>
-                    <value>DAILY</value>
+                    <value>WEEKLY</value>
                 </entry>
             </job-data-map>
         </job>
@@ -553,6 +554,7 @@
                 <cron-expression>0 0 11 ? * WED</cron-expression>
             </cron>
         </trigger>
+
         <!-- Chart data creator -->
         <job>
             <name>chartDataCreator</name>
@@ -572,7 +574,7 @@
                 <cron-expression>0 30 02 * * ?</cron-expression> <!-- At 0230 UTC every day -->
             </cron>
         </trigger>
-        
+
         <!-- API Key Delete Warning Job -->
         <job>
             <name>apiKeyDeleteWarningEmailJob</name>
@@ -592,7 +594,7 @@
                 <cron-expression>0 0 4 1/1 * ? *</cron-expression> <!-- At 0400 UTC every day -->
             </cron>
         </trigger>
-        
+
         <!-- API Key Delete Job -->
         <job>
             <name>apiKeyDeleteJob</name>
@@ -612,6 +614,7 @@
                 <cron-expression>0 30 4 1/1 * ? *</cron-expression> <!-- At 0430 UTC every day -->
             </cron>
         </trigger>
+
         <!-- Job used to trigger interruptions of other jobs -->
         <job>
             <name>interruptJob</name>

--- a/chpl/chpl-service/src/main/resources/jobs.xml
+++ b/chpl/chpl-service/src/main/resources/jobs.xml
@@ -9,45 +9,6 @@
         <delete-triggers-in-group>interruptJob</delete-triggers-in-group>
     </pre-processing-commands>
     <schedule>
-        <!-- API Key Delete Warning Job -->
-        <job>
-            <name>apiKeyDeleteWarningEmailJob</name>
-            <group>systemJobs</group>
-            <description>Send email to API key holders, where the API key hasn't been used in X days</description>
-            <job-class>gov.healthit.chpl.scheduler.job.ApiKeyWarningEmailJob</job-class>
-            <durability>true</durability>
-            <recover>true</recover>
-        </job>
-        <trigger>
-            <cron>
-                <name>apiKeyDeleteWarningEmail</name>
-                <group>apiKeyDeleteWarningEmailTrigger</group>
-                <job-name>apiKeyDeleteWarningEmailJob</job-name>
-                <job-group>systemJobs</job-group>
-                <misfire-instruction>MISFIRE_INSTRUCTION_FIRE_ONCE_NOW</misfire-instruction>
-                <cron-expression>0 55 10 1/1 * ? *</cron-expression> <!-- At 0445 UTC on the first Saturday of the quarter -->
-            </cron>
-        </trigger>
-        <!-- API Key Delete Job -->
-        <job>
-            <name>apiKeyDeleteJob</name>
-            <group>systemJobs</group>
-            <description>Send email to API key holders where a warning email has been sent, after x days of inactivity, and delete the key</description>
-            <job-class>gov.healthit.chpl.scheduler.job.ApiKeyDeleteJob</job-class>
-            <durability>true</durability>
-            <recover>true</recover>
-        </job>
-        <trigger>
-            <cron>
-                <name>apiKeyDeleteEmail</name>
-                <group>apiKeyDeleteTrigger</group>
-                <job-name>apiKeyDeleteJob</job-name>
-                <job-group>systemJobs</job-group>
-                <misfire-instruction>MISFIRE_INSTRUCTION_FIRE_ONCE_NOW</misfire-instruction>
-                <cron-expression>0 35 10 1/1 * ? *</cron-expression> <!-- At 0445 UTC on the first Saturday of the quarter -->
-            </cron>
-        </trigger>
-
         <!-- Cache status age notification -->
         <job>
             <name>Cache Status Age</name>
@@ -90,7 +51,7 @@
                 <job-name>downloadFileJob2015</job-name>
                 <job-group>systemJobs</job-group>
                 <misfire-instruction>MISFIRE_INSTRUCTION_DO_NOTHING</misfire-instruction>
-                <cron-expression>0 30 4 * * ?</cron-expression> <!-- At 0430 UTC every day -->
+                <cron-expression>0 0 5 * * ?</cron-expression> <!-- At 0500 UTC every day -->
             </cron>
         </trigger>
 
@@ -115,7 +76,7 @@
                 <job-name>downloadFileJob2014</job-name>
                 <job-group>systemJobs</job-group>
                 <misfire-instruction>MISFIRE_INSTRUCTION_DO_NOTHING</misfire-instruction>
-                <cron-expression>0 35 4 * * ?</cron-expression> <!-- At 0435 UTC every day -->
+                <cron-expression>0 30 6 * * ?</cron-expression> <!-- At 0630 UTC every day -->
             </cron>
         </trigger>
 
@@ -160,7 +121,7 @@
                 <job-name>g3Sed2015DownloadFileJob</job-name>
                 <job-group>systemJobs</job-group>
                 <misfire-instruction>MISFIRE_INSTRUCTION_DO_NOTHING</misfire-instruction>
-                <cron-expression>0 50 4 * * ?</cron-expression> <!-- At 0450 UTC every day -->
+                <cron-expression>0 30 3 * * ?</cron-expression> <!-- At 0330 UTC every day -->
             </cron>
         </trigger>
 
@@ -180,7 +141,7 @@
                 <job-name>surveillanceDownloadFileJob</job-name>
                 <job-group>systemJobs</job-group>
                 <misfire-instruction>MISFIRE_INSTRUCTION_DO_NOTHING</misfire-instruction>
-                <cron-expression>0 55 4 * * ?</cron-expression> <!-- At 0455 UTC every day -->
+                <cron-expression>0 15 4 * * ?</cron-expression> <!-- At 0415 UTC every day -->
             </cron>
         </trigger>
 
@@ -206,7 +167,7 @@
                 <job-name>summaryStatisticsCreator</job-name>
                 <job-group>systemJobs</job-group>
                 <misfire-instruction>MISFIRE_INSTRUCTION_DO_NOTHING</misfire-instruction>
-                <cron-expression>0 3 1 * * ?</cron-expression> <!-- At 0103 UTC every day -->
+                <cron-expression>0 0 4 * * ?</cron-expression> <!-- At 0400 UTC every day -->
             </cron>
         </trigger>
 
@@ -433,25 +394,7 @@
                 </entry>
             </job-data-map>
         </job>
-        <!-- Chart data creator -->
-        <job>
-            <name>chartDataCreator</name>
-            <group>systemJobs</group>
-            <description>Generates the chart data</description>
-            <job-class>gov.healthit.chpl.scheduler.job.chartdata.ChartDataCreatorJob</job-class>
-            <durability>true</durability>
-            <recover>false</recover>
-        </job>
-        <trigger>
-            <cron>
-                <name>generateChartData</name>
-                <group>chartDataCreatorTrigger</group>
-                <job-name>chartDataCreator</job-name>
-                <job-group>systemJobs</job-group>
-                <misfire-instruction>MISFIRE_INSTRUCTION_DO_NOTHING</misfire-instruction>
-                <cron-expression>0 30 02 * * ?</cron-expression> <!-- At 0230 UTC every day -->
-            </cron>
-        </trigger>
+
         <!-- Questionable Activity data emailer -->
         <job>
             <name>Questionable Activity Report</name>
@@ -471,6 +414,66 @@
                 </entry>
             </job-data-map>
         </job>
+
+        <!-- Chart data creator -->
+        <job>
+            <name>chartDataCreator</name>
+            <group>systemJobs</group>
+            <description>Generates the chart data</description>
+            <job-class>gov.healthit.chpl.scheduler.job.chartdata.ChartDataCreatorJob</job-class>
+            <durability>true</durability>
+            <recover>false</recover>
+        </job>
+        <trigger>
+            <cron>
+                <name>generateChartData</name>
+                <group>chartDataCreatorTrigger</group>
+                <job-name>chartDataCreator</job-name>
+                <job-group>systemJobs</job-group>
+                <misfire-instruction>MISFIRE_INSTRUCTION_DO_NOTHING</misfire-instruction>
+                <cron-expression>0 30 02 * * ?</cron-expression> <!-- At 0230 UTC every day -->
+            </cron>
+        </trigger>
+
+        <!-- API Key Delete Warning Job -->
+        <job>
+            <name>apiKeyDeleteWarningEmailJob</name>
+            <group>systemJobs</group>
+            <description>Send email to API key holders, where the API key hasn't been used in X days</description>
+            <job-class>gov.healthit.chpl.scheduler.job.ApiKeyWarningEmailJob</job-class>
+            <durability>true</durability>
+            <recover>true</recover>
+        </job>
+        <trigger>
+            <cron>
+                <name>apiKeyDeleteWarningEmail</name>
+                <group>apiKeyDeleteWarningEmailTrigger</group>
+                <job-name>apiKeyDeleteWarningEmailJob</job-name>
+                <job-group>systemJobs</job-group>
+                <misfire-instruction>MISFIRE_INSTRUCTION_FIRE_ONCE_NOW</misfire-instruction>
+                <cron-expression>0 0 4 1/1 * ? *</cron-expression> <!-- At 0400 UTC every day -->
+            </cron>
+        </trigger>
+
+        <!-- API Key Delete Job -->
+        <job>
+            <name>apiKeyDeleteJob</name>
+            <group>systemJobs</group>
+            <description>Send email to API key holders where a warning email has been sent, after x days of inactivity, and delete the key</description>
+            <job-class>gov.healthit.chpl.scheduler.job.ApiKeyDeleteJob</job-class>
+            <durability>true</durability>
+            <recover>true</recover>
+        </job>
+        <trigger>
+            <cron>
+                <name>apiKeyDeleteEmail</name>
+                <group>apiKeyDeleteTrigger</group>
+                <job-name>apiKeyDeleteJob</job-name>
+                <job-group>systemJobs</job-group>
+                <misfire-instruction>MISFIRE_INSTRUCTION_FIRE_ONCE_NOW</misfire-instruction>
+                <cron-expression>0 30 4 1/1 * ? *</cron-expression> <!-- At 0430 UTC every day -->
+            </cron>
+        </trigger>
 
         <!-- Job used to trigger interruptions of other jobs -->
         <job>


### PR DESCRIPTION
 * Serialize download file generation on DEV, PROD, Local
 * Sort all jobs/triggers the same way in DEV, STG, Local

[#quartz]

PR'd to STG so it can go to PROD on Monday. Not sure if it matters for our download file generation issue, but can't hurt