### PR TITLE
test: fix unit tests

### DIFF
--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/chartdata/CriterionProductStatisticsChartDataAppTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/chartdata/CriterionProductStatisticsChartDataAppTest.java
@@ -7,7 +7,6 @@ import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.ServletException;
 
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/chartdata/CriterionProductStatisticsChartDataAppTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/chartdata/CriterionProductStatisticsChartDataAppTest.java
@@ -7,6 +7,7 @@ import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.ServletException;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -61,13 +62,12 @@ public class CriterionProductStatisticsChartDataAppTest extends TestCase {
      */
     @BeforeClass
     public static void setup() throws ServletException {
-        try (AnnotationConfigWebApplicationContext wac = new AnnotationConfigWebApplicationContext()) {
-            wac.register(CHPLTestConfig.class);
-            MockServletContext sc = new MockServletContext("");
-            ServletContextListener listener = new ContextLoaderListener(wac);
-            ServletContextEvent event = new ServletContextEvent(sc);
-            listener.contextInitialized(event);
-        }
+        AnnotationConfigWebApplicationContext wac = new AnnotationConfigWebApplicationContext();
+        wac.register(CHPLTestConfig.class);
+        MockServletContext sc = new MockServletContext("");
+        ServletContextListener listener = new ContextLoaderListener(wac);
+        ServletContextEvent event = new ServletContextEvent(sc);
+        listener.contextInitialized(event);
     }
 
     @Test

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/chartdata/IncumbentDevelopersStatisticsChartDataAppTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/chartdata/IncumbentDevelopersStatisticsChartDataAppTest.java
@@ -6,7 +6,6 @@ import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.ServletException;
 
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/chartdata/IncumbentDevelopersStatisticsChartDataAppTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/chartdata/IncumbentDevelopersStatisticsChartDataAppTest.java
@@ -6,6 +6,7 @@ import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.ServletException;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -66,13 +67,12 @@ public class IncumbentDevelopersStatisticsChartDataAppTest extends TestCase {
      */
     @BeforeClass
     public static void setup() throws ServletException {
-        try (AnnotationConfigWebApplicationContext wac = new AnnotationConfigWebApplicationContext()) {
-            wac.register(CHPLTestConfig.class);
-            MockServletContext sc = new MockServletContext("");
-            ServletContextListener listener = new ContextLoaderListener(wac);
-            ServletContextEvent event = new ServletContextEvent(sc);
-            listener.contextInitialized(event);
-        }
+        AnnotationConfigWebApplicationContext wac = new AnnotationConfigWebApplicationContext();
+        wac.register(CHPLTestConfig.class);
+        MockServletContext sc = new MockServletContext("");
+        ServletContextListener listener = new ContextLoaderListener(wac);
+        ServletContextEvent event = new ServletContextEvent(sc);
+        listener.contextInitialized(event);
     }
 
     @Test

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/chartdata/ListingCountStatisticsChartDataAppTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/chartdata/ListingCountStatisticsChartDataAppTest.java
@@ -6,7 +6,6 @@ import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.ServletException;
 
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -14,7 +13,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.web.context.ContextLoader;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/chartdata/ListingCountStatisticsChartDataAppTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/chartdata/ListingCountStatisticsChartDataAppTest.java
@@ -6,6 +6,7 @@ import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.ServletException;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -63,19 +64,19 @@ public class ListingCountStatisticsChartDataAppTest extends TestCase {
     @Autowired
     public UnitTestRules cacheInvalidationRule;
 
+
     /**
      * create an application context that the statistics calculator requires
      * @throws ServletException
      */
     @BeforeClass
     public static void setup() throws ServletException {
-        try (AnnotationConfigWebApplicationContext wac = new AnnotationConfigWebApplicationContext()) {
-            wac.register(CHPLTestConfig.class);
-            MockServletContext sc = new MockServletContext("");
-            ServletContextListener listener = new ContextLoaderListener(wac);
-            ServletContextEvent event = new ServletContextEvent(sc);
-            listener.contextInitialized(event);
-        }
+        AnnotationConfigWebApplicationContext wac = new AnnotationConfigWebApplicationContext();
+        wac.register(CHPLTestConfig.class);
+        MockServletContext sc = new MockServletContext("");
+        ServletContextListener listener = new ContextLoaderListener(wac);
+        ServletContextEvent event = new ServletContextEvent(sc);
+        listener.contextInitialized(event);
     }
 
     @Test

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/chartdata/NonconformityTypeChartDataAppTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/chartdata/NonconformityTypeChartDataAppTest.java
@@ -1,18 +1,11 @@
 package gov.healthit.chpl.app.chartdata;
 
-import gov.healthit.chpl.CHPLTestConfig;
-import gov.healthit.chpl.dto.NonconformityTypeStatisticsDTO;
-import gov.healthit.chpl.scheduler.job.chartdata.NonconformityTypeChartCalculator;
-
 import java.util.List;
 
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.ServletException;
 
-import junit.framework.TestCase;
-
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,6 +22,11 @@ import org.springframework.web.context.support.AnnotationConfigWebApplicationCon
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
+
+import gov.healthit.chpl.CHPLTestConfig;
+import gov.healthit.chpl.dto.NonconformityTypeStatisticsDTO;
+import gov.healthit.chpl.scheduler.job.chartdata.NonconformityTypeChartCalculator;
+import junit.framework.TestCase;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/chartdata/NonconformityTypeChartDataAppTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/chartdata/NonconformityTypeChartDataAppTest.java
@@ -12,6 +12,7 @@ import javax.servlet.ServletException;
 
 import junit.framework.TestCase;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,13 +47,12 @@ public class NonconformityTypeChartDataAppTest extends TestCase {
      */
     @BeforeClass
     public static void setup() throws ServletException {
-        try (AnnotationConfigWebApplicationContext wac = new AnnotationConfigWebApplicationContext()) {
-            wac.register(CHPLTestConfig.class);
-            MockServletContext sc = new MockServletContext("");
-            ServletContextListener listener = new ContextLoaderListener(wac);
-            ServletContextEvent event = new ServletContextEvent(sc);
-            listener.contextInitialized(event);
-        }
+        AnnotationConfigWebApplicationContext wac = new AnnotationConfigWebApplicationContext();
+        wac.register(CHPLTestConfig.class);
+        MockServletContext sc = new MockServletContext("");
+        ServletContextListener listener = new ContextLoaderListener(wac);
+        ServletContextEvent event = new ServletContextEvent(sc);
+        listener.contextInitialized(event);
     }
 
     @Test


### PR DESCRIPTION

Eclipse reported a potential leak with the context not being closed.
Closing that context in the @BeforeClass had it closed before it could
be used in the tests. It can't be closed in an @afterclass because
tests then fail depending on the order in which they're run. This
commit undoes the previous "fix", though it leaves the Eclipse error
still around. No fix for that is immediately apparent.