### PR TITLE
fix: add system-status call to swagger docs

### DIFF
--- a/chpl/chpl-api/src/main/java/gov/healthit/chpl/SwaggerConfig.java
+++ b/chpl/chpl-api/src/main/java/gov/healthit/chpl/SwaggerConfig.java
@@ -68,7 +68,7 @@ public class SwaggerConfig implements EnvironmentAware {
                 regex("/certification_ids.*"), regex("/certified_products.*"), regex("/certified_product_details.*"),
                 regex("/collections.*"), regex("/data/.*"), regex("/download.*"), regex("/files.*"), regex("/jobs.*"),
                 regex("/key.*"), regex("/meaningful_use.*"), regex("/products.*"),
-                regex("/search.*"), regex("/surveillance.*"), regex("/status"), regex("/cache_status"),
+                regex("/search.*"), regex("/surveillance.*"), regex("/status"), regex("/cache_status"), regex("/system-status"),
                 regex("/users.*"), regex("/developers.*"), regex("/versions.*"), regex("/decertifications/.*"),
                 regex("/schedules.*"));
     }


### PR DESCRIPTION
While starting to add AQA test, realized the new status call wasn't in the swagger docs