### PR TITLE
OCD-2808 Fix issue with pending listing metadata err/warn count

### DIFF
--- a/chpl/chpl-api/src/main/java/gov/healthit/chpl/web/controller/CertifiedProductController.java
+++ b/chpl/chpl-api/src/main/java/gov/healthit/chpl/web/controller/CertifiedProductController.java
@@ -789,17 +789,7 @@ public class CertifiedProductController {
     public @ResponseBody String rejectPendingCertifiedProduct(@PathVariable("pcpId") final Long pcpId)
             throws EntityRetrievalException, JsonProcessingException, EntityCreationException, EntityNotFoundException,
             AccessDeniedException, ObjectMissingValidationException {
-        PendingCertifiedProductDetails pcp = pcpManager.getById(pcpId, true);
-        Long pendingListingAcbId = null;
-        if (pcp == null) {
-            throw new EntityNotFoundException(msgUtil.getMessage("pendingListing.notFound"));
-        } else {
-            //make sure the user has permissions on the pending listings acb
-            //will throw access denied if they do not have the permissions
-            pendingListingAcbId = new Long(pcp.getCertifyingBody().get(CertifiedProductSearchDetails.ACB_ID_KEY).toString());
-            resourcePermissions.getAcbIfPermissionById(pendingListingAcbId);
-        }
-        pcpManager.deletePendingCertifiedProduct(pendingListingAcbId, pcpId);
+        pcpManager.deletePendingCertifiedProduct(pcpId);
         return "{\"success\" : true}";
     }
 
@@ -812,12 +802,6 @@ public class CertifiedProductController {
             throws EntityRetrievalException, JsonProcessingException, EntityCreationException, EntityNotFoundException,
             AccessDeniedException, InvalidArgumentsException, ObjectsMissingValidationException {
 
-        return deletePendingCertifiedProducts(idList);
-    }
-
-    private String deletePendingCertifiedProducts(final IdListContainer idList)
-            throws EntityRetrievalException, JsonProcessingException, EntityCreationException, EntityNotFoundException,
-            AccessDeniedException, InvalidArgumentsException, ObjectsMissingValidationException {
         if (idList == null || idList.getIds() == null || idList.getIds().size() == 0) {
             throw new InvalidArgumentsException("At least one id must be provided for rejection.");
         }
@@ -825,11 +809,7 @@ public class CertifiedProductController {
         ObjectsMissingValidationException possibleExceptions = new ObjectsMissingValidationException();
         for (Long pcpId : idList.getIds()) {
             try {
-                Long acbId = pcpDao.findAcbIdById(pcpId);
-                if (acbId == null) {
-                    throw new EntityNotFoundException(msgUtil.getMessage("pendingListing.notFound"));
-                }
-                pcpManager.deletePendingCertifiedProduct(acbId, pcpId);
+                pcpManager.deletePendingCertifiedProduct(pcpId);
             } catch (final ObjectMissingValidationException ex) {
                 possibleExceptions.getExceptions().add(ex);
             }

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/PendingCertifiedProductManager.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/manager/PendingCertifiedProductManager.java
@@ -31,15 +31,12 @@ public interface PendingCertifiedProductManager {
     PendingCertifiedProductDTO createOrReplace(Long acbId, PendingCertifiedProductEntity toCreate)
             throws EntityRetrievalException, EntityCreationException, JsonProcessingException;
 
-    void deletePendingCertifiedProduct(final Long acbId, Long pendingProductId)
+    void deletePendingCertifiedProduct(Long pendingProductId)
             throws EntityRetrievalException, EntityNotFoundException, EntityCreationException, AccessDeniedException,
             JsonProcessingException, ObjectMissingValidationException;
 
     void confirm(Long acbId, Long pendingProductId)
             throws EntityRetrievalException, JsonProcessingException, EntityCreationException;
-
-    boolean isPendingListingAvailableForUpdate(Long acbId, PendingCertifiedProductDTO pendingCp)
-            throws EntityRetrievalException, ObjectMissingValidationException;
 
     boolean isPendingListingAvailableForUpdate(Long acbId, Long pendingProductId)
             throws EntityRetrievalException, ObjectMissingValidationException;

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/permissions/domains/pendingcertifiedproduct/DeleteActionPermissions.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/permissions/domains/pendingcertifiedproduct/DeleteActionPermissions.java
@@ -1,11 +1,22 @@
 package gov.healthit.chpl.permissions.domains.pendingcertifiedproduct;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
+import gov.healthit.chpl.dao.PendingCertifiedProductDAO;
+import gov.healthit.chpl.dto.listing.pending.PendingCertifiedProductDTO;
+import gov.healthit.chpl.exception.EntityRetrievalException;
 import gov.healthit.chpl.permissions.domains.ActionPermissions;
 
 @Component("pendingCertifiedProductDeleteActionPermissions")
 public class DeleteActionPermissions extends ActionPermissions {
+    private PendingCertifiedProductDAO pcpDao;
+
+    @Autowired
+    public DeleteActionPermissions(final PendingCertifiedProductDAO pcpDao) {
+        this.pcpDao = pcpDao;
+    }
 
     @Override
     public boolean hasAccess() {
@@ -13,14 +24,26 @@ public class DeleteActionPermissions extends ActionPermissions {
     }
 
     @Override
-    public boolean hasAccess(Object obj) {
+    @Transactional
+    public boolean hasAccess(final Object obj) {
         if (!(obj instanceof Long)) {
             return false;
         } else if (getResourcePermissions().isUserRoleAdmin()) {
             return true;
         } else if (getResourcePermissions().isUserRoleAcbAdmin()) {
-            Long acbId = (Long) obj;
-            return isAcbValidForCurrentUser(acbId);
+            Long pcpId = (Long) obj;
+            try {
+                Long acbId = pcpDao.findAcbIdById(pcpId);
+                if (acbId != null) {
+                    return isAcbValidForCurrentUser(acbId);
+                } else {
+                    //cannot determine acb for unknown reason
+                    return false;
+                }
+            } catch (EntityRetrievalException ex) {
+                //bad pcp id passed in
+                return false;
+            }
         } else {
             return false;
         }

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/validation/pendingListing/reviewer/edition2015/RequiredData2015Reviewer.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/validation/pendingListing/reviewer/edition2015/RequiredData2015Reviewer.java
@@ -773,7 +773,7 @@ public class RequiredData2015Reviewer extends RequiredDataReviewer {
                 if (certRules.hasCertOption(cert.getNumber(), CertificationResultRules.TEST_PROCEDURE)
                         && cert.getTestProcedures() != null && cert.getTestProcedures().size() > 0) {
                     for (PendingCertificationResultTestProcedureDTO crTestProc : cert.getTestProcedures()) {
-                        if (crTestProc.getTestProcedure() == null || crTestProc.getTestProcedureId() == null) {
+                        if (crTestProc.getTestProcedure() == null && crTestProc.getTestProcedureId() == null) {
                             listing.getErrorMessages().add(
                                     msgUtil.getMessage("listing.criteria.badTestProcedureName",
                                             cert.getNumber(), crTestProc.getEnteredName()));
@@ -781,7 +781,7 @@ public class RequiredData2015Reviewer extends RequiredDataReviewer {
                             TestProcedureDTO foundTestProc =
                                     testProcDao.getByCriteriaNumberAndValue(cert.getNumber(),
                                             crTestProc.getTestProcedure().getName());
-                            if(foundTestProc == null || foundTestProc.getId() == null) {
+                            if (foundTestProc == null || foundTestProc.getId() == null) {
                                 listing.getErrorMessages().add(
                                         msgUtil.getMessage("listing.criteria.badTestProcedureName",
                                                 cert.getNumber(), crTestProc.getTestProcedure().getName()));
@@ -800,7 +800,7 @@ public class RequiredData2015Reviewer extends RequiredDataReviewer {
                 if (certRules.hasCertOption(cert.getNumber(), CertificationResultRules.TEST_DATA)
                         && cert.getTestData() != null && cert.getTestData().size() > 0) {
                     for (PendingCertificationResultTestDataDTO crTestData : cert.getTestData()) {
-                        if (crTestData.getTestData() == null || crTestData.getTestDataId() == null) {
+                        if (crTestData.getTestData() == null && crTestData.getTestDataId() == null) {
                             listing.getWarningMessages().add(
                                     msgUtil.getMessage("listing.criteria.badTestDataName",
                                             crTestData.getEnteredName(), cert.getNumber(), TestDataDTO.DEFALUT_TEST_DATA));

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/permissions/domain/pendingcertifiedproduct/DeleteActionPermissionsTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/app/permissions/domain/pendingcertifiedproduct/DeleteActionPermissionsTest.java
@@ -6,15 +6,18 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import gov.healthit.chpl.app.permissions.domain.ActionPermissionsBaseTest;
+import gov.healthit.chpl.dao.PendingCertifiedProductDAO;
 import gov.healthit.chpl.permissions.ResourcePermissions;
 import gov.healthit.chpl.permissions.domains.pendingcertifiedproduct.DeleteActionPermissions;
 
@@ -26,6 +29,9 @@ public class DeleteActionPermissionsTest extends ActionPermissionsBaseTest {
     @Mock
     private ResourcePermissions resourcePermissions;
 
+    @Spy
+    private PendingCertifiedProductDAO pcpDao;
+
     @InjectMocks
     private DeleteActionPermissions permissions;
 
@@ -33,7 +39,7 @@ public class DeleteActionPermissionsTest extends ActionPermissionsBaseTest {
     public void setup() {
         MockitoAnnotations.initMocks(this);
 
-        Mockito.when(resourcePermissions.getAllAcbsForCurrentUser()).thenReturn(getAllAcbForUser(2l, 4l));
+        Mockito.when(resourcePermissions.getAllAcbsForCurrentUser()).thenReturn(getAllAcbForUser(2L, 4L));
     }
 
     @Override
@@ -65,12 +71,24 @@ public class DeleteActionPermissionsTest extends ActionPermissionsBaseTest {
     public void hasAccess_Acb() throws Exception {
         setupForAcbUser(resourcePermissions);
 
+        // Setup Mock
+        Mockito.when(pcpDao.findAcbIdById(ArgumentMatchers.anyLong())).thenReturn(2L);
+
         // This should always be false
         assertFalse(permissions.hasAccess());
+        assertTrue(permissions.hasAccess(-1L));
+    }
 
-        assertFalse(permissions.hasAccess(1L));
+    @Test
+    public void hasNoAccess_Acb() throws Exception {
+        setupForAcbUser(resourcePermissions);
 
-        assertTrue(permissions.hasAccess(2L));
+        // Setup Mock
+        Mockito.when(pcpDao.findAcbIdById(ArgumentMatchers.anyLong())).thenReturn(3L);
+
+        // This should always be false
+        assertFalse(permissions.hasAccess());
+        assertFalse(permissions.hasAccess(-1L));
     }
 
     @Override


### PR DESCRIPTION
I am still not sure why the validation was different on upload vs on inspect because the validator should have run through the same code both times... but there was a bit of logic in there that I think was wrong and fixing it fixed the issue. In the course of testing I felt like rejecting listings was taking a long time and part of the reason was the way the code is written was causing them to be validated before rejected which is not necessary. Re-worked the code a little bit to also make better use of the action permissions and eliminate the validation bit. It's slightly faster but it's just a lot of queries that run when getting a pending listing so it's still not super fast. Could be improved more in the future.