### PR TITLE
OCD-3737 : Update api AQA tests to not check for rwtEligibilityYear value

### DIFF
--- a/chpl/chpl-api/e2e/collections/certified-product-controller.postman_collection.json
+++ b/chpl/chpl-api/e2e/collections/certified-product-controller.postman_collection.json
@@ -88,7 +88,6 @@
 									"    pm.expect(expresult).to.have.property('rwtPlansCheckDate');\r",
 									"    pm.expect(expresult).to.have.property('rwtResultsUrl');\r",
 									"    pm.expect(expresult).to.have.property('rwtResultsCheckDate');\r",
-									"    pm.expect(expresult).to.have.property('rwtEligibilityYear');\r",
 									"});"
 								],
 								"type": "text/javascript"
@@ -204,7 +203,6 @@
 									"    pm.expect(expresp).to.have.property('rwtPlansCheckDate');\r",
 									"    pm.expect(expresp).to.have.property('rwtResultsUrl');\r",
 									"    pm.expect(expresp).to.have.property('rwtResultsCheckDate');\r",
-									"    pm.expect(expresp).to.have.property('rwtEligibilityYear');\r",
 									"});"
 								],
 								"type": "text/javascript"
@@ -569,7 +567,6 @@
 									"    pm.expect(expresult).to.have.property('rwtPlansCheckDate');\r",
 									"    pm.expect(expresult).to.have.property('rwtResultsUrl');\r",
 									"    pm.expect(expresult).to.have.property('rwtResultsCheckDate');\r",
-									"    pm.expect(expresult).to.have.property('rwtEligibilityYear');\r",
 									"});\r",
 									"pm.test(\"All RWT fields should be null for 2014/2011 listings\", function() {\r",
 									"    var jsonData = pm.response.json();\r",
@@ -577,7 +574,6 @@
 									"    pm.expect(jsonData.rwtPlansCheckDate).eq(null);\r",
 									"    pm.expect(jsonData.rwtResultsUrl).eq(null);\r",
 									"    pm.expect(jsonData.rwtResultsCheckDate).eq(null);\r",
-									"    pm.expect(jsonData.rwtEligibilityYear).eq(null);\r",
 									"});"
 								],
 								"type": "text/javascript"


### PR DESCRIPTION
OCD-3737 : Update api AQA tests to not check for rwtEligibilityYear value