### PR TITLE
OCD-3875 : update to AQA test to remove removed API response fields

### DIFF
--- a/chpl/chpl-api/e2e/collections/certified-product-controller.postman_collection.json
+++ b/chpl/chpl-api/e2e/collections/certified-product-controller.postman_collection.json
@@ -1,6 +1,5 @@
 {
 	"info": {
-		"_postman_id": "1e82ed5d-ea60-456b-8169-8d8a0cf2ff9f",
 		"name": "certified-product-controller",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},

--- a/chpl/chpl-api/e2e/collections/certified-product-controller.postman_collection.json
+++ b/chpl/chpl-api/e2e/collections/certified-product-controller.postman_collection.json
@@ -387,11 +387,9 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"pm.test(\"/search/beta end point response should have meaningfulUseUserHistory and promotingInteroperabilityUserHistory fields\", function () {\r",
+									"pm.test(\"/search/beta end point response should have promotingInteroperabilityUserHistory fields\", function () {\r",
 									"    var jsonData = pm.response.json();\r",
 									"    pm.response.to.have.status(200);\r",
-									"    pm.expect(jsonData.results[0]).to.have.property('numMeaningfulUse');\r",
-									"    pm.expect(jsonData.results[0]).to.have.property('numMeaningfulUseDate');\r",
 									"    pm.expect(jsonData.results[0]).to.have.property('promotingInteroperabilityUserCount');\r",
 									"    pm.expect(jsonData.results[0]).to.have.property('promotingInteroperabilityUserDate');\r",
 									"});"

--- a/chpl/chpl-api/e2e/collections/certified-product-controller.postman_collection.json
+++ b/chpl/chpl-api/e2e/collections/certified-product-controller.postman_collection.json
@@ -1,5 +1,6 @@
 {
 	"info": {
+		"_postman_id": "1e82ed5d-ea60-456b-8169-8d8a0cf2ff9f",
 		"name": "certified-product-controller",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -381,7 +382,7 @@
 					"response": []
 				},
 				{
-					"name": "GET /search/beta end point response should have meaningfulUseUserHistory and promotingInteroperabilityUserHistory fields",
+					"name": "GET /search/beta end point response should have promotingInteroperabilityUserHistory fields",
 					"event": [
 						{
 							"listen": "test",


### PR DESCRIPTION
OCD-3875 : update to AQA test to remove removed API response fields