### PR TITLE
OCD-4109: Resolve errors when editing listings with CHP- style numbers

### DIFF
--- a/chpl/chpl-resources/src/main/resources/jobs.xml
+++ b/chpl/chpl-resources/src/main/resources/jobs.xml
@@ -8,14 +8,7 @@
         <delete-triggers-in-group>triggerJob</delete-triggers-in-group>
         <delete-triggers-in-group>interruptJob</delete-triggers-in-group>
         <!-- BEGIN REMOVE after PROD push -->
-        <delete-job>
-            <name>surveillanceUploadJob</name>
-            <group>chplBackgroundJobs</group>
-        </delete-job>
-        <delete-job>
-            <name>inviteDevelopersJob</name>
-            <group>systemJobs</group>
-        </delete-job>
+
         <!-- END remove after PROD push -->
     </pre-processing-commands>
     <processing-directives>

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/scheduler/job/listingvalidation/ListingValidationCreatorJob.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/scheduler/job/listingvalidation/ListingValidationCreatorJob.java
@@ -28,6 +28,7 @@ import gov.healthit.chpl.domain.CertifiedProductSearchDetails;
 import gov.healthit.chpl.domain.concept.CertificationEditionConcept;
 import gov.healthit.chpl.dto.CertifiedProductDetailsDTO;
 import gov.healthit.chpl.exception.EntityRetrievalException;
+import gov.healthit.chpl.upload.listing.normalizer.ListingDetailsNormalizer;
 import gov.healthit.chpl.validation.listing.ListingValidatorFactory;
 import gov.healthit.chpl.validation.listing.Validator;
 import lombok.extern.log4j.Log4j2;
@@ -43,6 +44,9 @@ public class ListingValidationCreatorJob implements Job {
 
     @Autowired
     private CertifiedProductDAO certifiedProductDAO;
+
+    @Autowired
+    private ListingDetailsNormalizer listingNormalizer;
 
     @Autowired
     private ListingValidatorFactory validatorFactory;
@@ -125,6 +129,7 @@ public class ListingValidationCreatorJob implements Job {
 
     private CertifiedProductSearchDetails validateListing(CertifiedProductSearchDetails listing) {
         try {
+            listingNormalizer.normalize(listing);
             Validator validator = validatorFactory.getValidator(listing);
             validator.validate(listing);
             LOGGER.info("Completed validation of listing: " + listing.getId());

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/CertificationBodyNormalizer.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/CertificationBodyNormalizer.java
@@ -87,7 +87,7 @@ public class CertificationBodyNormalizer {
 
     private boolean isAcbPortionOfChplProductNumberValid(CertifiedProductSearchDetails listing) {
         return !StringUtils.isEmpty(listing.getChplProductNumber())
-                && validationUtils.chplNumberPartIsValid(listing.getChplProductNumber(),
+                && validationUtils.chplNumberPartIsPresentAndValid(listing.getChplProductNumber(),
                     ChplProductNumberUtil.ACB_CODE_INDEX,
                     ChplProductNumberUtil.ACB_CODE_REGEX);
     }

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/CertificationEditionNormalizer.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/CertificationEditionNormalizer.java
@@ -70,7 +70,7 @@ public class CertificationEditionNormalizer {
 
     private boolean isEditionPortionOfChplProductNumberValid(CertifiedProductSearchDetails listing) {
         return !StringUtils.isEmpty(listing.getChplProductNumber())
-                && validationUtils.chplNumberPartIsValid(listing.getChplProductNumber(),
+                && validationUtils.chplNumberPartIsPresentAndValid(listing.getChplProductNumber(),
                     ChplProductNumberUtil.EDITION_CODE_INDEX,
                     ChplProductNumberUtil.EDITION_CODE_REGEX);
     }

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/TestingLabNormalizer.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/TestingLabNormalizer.java
@@ -47,7 +47,7 @@ public class TestingLabNormalizer {
 
     private Boolean isTestingLabPortionOfChplProductNumberValid(CertifiedProductSearchDetails listing) {
         return !StringUtils.isEmpty(listing.getChplProductNumber())
-                && validationUtils.chplNumberPartIsValid(listing.getChplProductNumber(), ChplProductNumberUtil.ATL_CODE_INDEX, ChplProductNumberUtil.ATL_CODE_REGEX);
+                && validationUtils.chplNumberPartIsPresentAndValid(listing.getChplProductNumber(), ChplProductNumberUtil.ATL_CODE_INDEX, ChplProductNumberUtil.ATL_CODE_REGEX);
     }
 
     private void updateTestingLabFromChplProductNumber(CertifiedProductSearchDetails listing) {

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/util/ValidationUtils.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/util/ValidationUtils.java
@@ -55,6 +55,17 @@ public class ValidationUtils {
         return true;
     }
 
+    public boolean chplNumberPartIsPresentAndValid(String chplProductNumber, int partIndex, String regexToMatch) {
+        String[] uniqueIdParts = chplProductNumber.split("\\.");
+        if (uniqueIdParts.length == ChplProductNumberUtil.CHPL_PRODUCT_ID_PARTS) {
+            String chplNumberPart = uniqueIdParts[partIndex];
+            if (!StringUtils.isEmpty(chplNumberPart) && chplNumberPart.matches(regexToMatch)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public boolean isValidUtf8(String input) {
         return isValidUtf8(Charset.defaultCharset(), input);
     }

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/upload/listing/normalizer/CertificationBodyNormalizerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/upload/listing/normalizer/CertificationBodyNormalizerTest.java
@@ -46,6 +46,24 @@ public class CertificationBodyNormalizerTest {
         acb.put(CertifiedProductSearchDetails.ACB_NAME_KEY, "Drummond");
         acb.put(CertifiedProductSearchDetails.ACB_CODE_KEY, "04");
         CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
+                .chplProductNumber("15.07.04.2663.ABCD.R2.01.0.200511")
+                .certifyingBody(acb)
+                .build();
+        normalizer.normalize(listing);
+
+        assertEquals(1L, MapUtils.getLong(listing.getCertifyingBody(), CertifiedProductSearchDetails.ACB_ID_KEY));
+        assertEquals("Drummond", MapUtils.getString(listing.getCertifyingBody(), CertifiedProductSearchDetails.ACB_NAME_KEY));
+        assertEquals("04", MapUtils.getString(listing.getCertifyingBody(), CertifiedProductSearchDetails.ACB_CODE_KEY));
+    }
+
+    @Test
+    public void normalize_acbIdYearCodeExistLegacyChplProductNumber_noChanges() {
+        Map<String, Object> acb = new HashMap<String, Object>();
+        acb.put(CertifiedProductSearchDetails.ACB_ID_KEY, 1L);
+        acb.put(CertifiedProductSearchDetails.ACB_NAME_KEY, "Drummond");
+        acb.put(CertifiedProductSearchDetails.ACB_CODE_KEY, "04");
+        CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
+                .chplProductNumber("CHP-123456")
                 .certifyingBody(acb)
                 .build();
         normalizer.normalize(listing);
@@ -319,6 +337,17 @@ public class CertificationBodyNormalizerTest {
     public void normalize_acbInvalidAcbCodeMissingInChplProductNumber_noLookup() throws EntityRetrievalException {
         CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
                 .chplProductNumber("15.07.?M.2663.ABCD.R2.01.0.200511")
+                .build();
+
+        normalizer.normalize(listing);
+
+        assertNull(listing.getCertifyingBody());
+    }
+
+    @Test
+    public void normalize_acbMissingLegacyChplProductNumber_noLookup() throws EntityRetrievalException {
+        CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
+                .chplProductNumber("CHP-123456")
                 .build();
 
         normalizer.normalize(listing);

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/upload/listing/normalizer/CertificationEditionNormalizerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/upload/listing/normalizer/CertificationEditionNormalizerTest.java
@@ -40,17 +40,33 @@ public class CertificationEditionNormalizerTest {
     }
 
     @Test
-    public void normalize_editionIdAndYearExist_noChanges() {
+    public void normalize_editionIdAndYearExist_normalChplProductNumber_noChanges() {
         Map<String, Object> edition = new HashMap<String, Object>();
         edition.put(CertifiedProductSearchDetails.EDITION_ID_KEY, 1L);
         edition.put(CertifiedProductSearchDetails.EDITION_NAME_KEY, "2015");
         CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
+                .chplProductNumber("15.07.04.2663.ABCD.R2.01.0.200511")
                 .certificationEdition(edition)
                 .build();
         normalizer.normalize(listing);
 
         assertEquals(1L, MapUtils.getLong(listing.getCertificationEdition(), CertifiedProductSearchDetails.EDITION_ID_KEY));
         assertEquals("2015", MapUtils.getString(listing.getCertificationEdition(), CertifiedProductSearchDetails.EDITION_NAME_KEY));
+    }
+
+    @Test
+    public void normalize_editionIdAndYearExist_legacyChplProductNumber_noChanges() {
+        Map<String, Object> edition = new HashMap<String, Object>();
+        edition.put(CertifiedProductSearchDetails.EDITION_ID_KEY, 2L);
+        edition.put(CertifiedProductSearchDetails.EDITION_NAME_KEY, "2014");
+        CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
+                .chplProductNumber("CHP-123456")
+                .certificationEdition(edition)
+                .build();
+        normalizer.normalize(listing);
+
+        assertEquals(2L, MapUtils.getLong(listing.getCertificationEdition(), CertifiedProductSearchDetails.EDITION_ID_KEY));
+        assertEquals("2014", MapUtils.getString(listing.getCertificationEdition(), CertifiedProductSearchDetails.EDITION_NAME_KEY));
     }
 
     @Test
@@ -263,6 +279,16 @@ public class CertificationEditionNormalizerTest {
     public void normalize_editionMissingEditionCodeInvalidInChplProductNumber_noLookup() throws EntityRetrievalException {
         CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
                 .chplProductNumber("??.07.07.2663.ABCD.R2.01.0.200511")
+                .build();
+
+        normalizer.normalize(listing);
+        assertNull(listing.getCertificationEdition());
+    }
+
+    @Test
+    public void normalize_editionMissingLegacyChplProductNumber_noLookup() throws EntityRetrievalException {
+        CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
+                .chplProductNumber("CHP-123456")
                 .build();
 
         normalizer.normalize(listing);

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/upload/listing/normalizer/TestingLabNormalizerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/upload/listing/normalizer/TestingLabNormalizerTest.java
@@ -58,6 +58,27 @@ public class TestingLabNormalizerTest {
                 .testingLabCode("TL")
                 .build());
         CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
+                .chplProductNumber("15.07.04.2663.ABCD.R2.01.0.200511")
+                .testingLabs(atls)
+                .build();
+        normalizer.normalize(listing);
+
+        assertEquals(1, listing.getTestingLabs().size());
+        assertEquals(1L, listing.getTestingLabs().get(0).getTestingLabId());
+        assertEquals("ICSA", listing.getTestingLabs().get(0).getTestingLabName());
+        assertEquals("TL", listing.getTestingLabs().get(0).getTestingLabCode());
+    }
+
+    @Test
+    public void normalize_testingLabIdNameCodeExistLegacyChplProductNumber_noLookup() {
+        List<CertifiedProductTestingLab> atls = new ArrayList<CertifiedProductTestingLab>();
+        atls.add(CertifiedProductTestingLab.builder()
+                .testingLabId(1L)
+                .testingLabName("ICSA")
+                .testingLabCode("TL")
+                .build());
+        CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
+                .chplProductNumber("CHP-123456")
                 .testingLabs(atls)
                 .build();
         normalizer.normalize(listing);
@@ -288,6 +309,19 @@ public class TestingLabNormalizerTest {
         List<CertifiedProductTestingLab> atls = new ArrayList<CertifiedProductTestingLab>();
         CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
                 .chplProductNumber("15.T?.04.2663.ABCD.R2.01.0.200511")
+                .testingLabs(atls)
+                .build();
+
+        normalizer.normalize(listing);
+
+        assertEquals(0, listing.getTestingLabs().size());
+    }
+
+    @Test
+    public void normalize_atlsEmptyLegacyChplProductNumber_noLookup() throws EntityRetrievalException {
+        List<CertifiedProductTestingLab> atls = new ArrayList<CertifiedProductTestingLab>();
+        CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
+                .chplProductNumber("CHP-123456")
                 .testingLabs(atls)
                 .build();
 


### PR DESCRIPTION
Some of the normalizer code which was referenced during listing edit was not handling the format of legacy CHPL product numbers correctly.

[#OCD-4109]