### PR TITLE
OCD-4183: Handle "Jira Unavailable" better in Listing Search Service

### DIFF
--- a/chpl/chpl-resources/src/main/resources/errors.properties
+++ b/chpl/chpl-resources/src/main/resources/errors.properties
@@ -757,7 +757,6 @@ search.searchOperator.invalid=Invalid search operator value '%s'. Value must be 
 search.practiceType.invalid=Could not find practice type with name '%s'.
 search.certificationDate.invalid=Could not parse '%s' as date in the format %s.
 search.compliance.missingSearchOperator=Multiple non-conformity search options were found without a search operator (AND/OR). A search operator is required.
-search.complianceFilter.unavailable=Compliance and non-conformity filtering is unavailable at this time.
 search.hasHadSurveillance.invalid=Parameter value '%s' for hasHadSurveillance is invalid. It must be either 'true' or 'false'.
 search.hasHadComplianceActivity.invalid=Parameter value '%s' for hasHadComplianceActivity is invalid. It must be either 'true' or 'false'.
 search.nonconformitySearchOption.invalid=No non-conformity search option matches '%s'. Values must be one of %s.

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/compliance/directreview/DirectReviewCachingService.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/compliance/directreview/DirectReviewCachingService.java
@@ -113,9 +113,8 @@ public class DirectReviewCachingService {
                     + "currently has at least one record with 'OK' data. Not replacing the cache contents.");
         } else {
             replaceAllDataInDirectReviewCache(allDirectReviews, calculatedHttpStatus, logger);
+            directReviewListingSharedStoreHandler.handler(allDirectReviews, logger);
         }
-
-        directReviewListingSharedStoreHandler.handler(allDirectReviews, logger);
     }
 
     public boolean doesCacheHaveAnyOkData() {

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/search/SearchRequestValidator.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/search/SearchRequestValidator.java
@@ -307,19 +307,9 @@ public class SearchRequestValidator {
 
     private Set<String> getComplianceActivityErrors(ComplianceSearchFilter complianceFilter) {
         Set<String> errors = new LinkedHashSet<String>();
-        if (hasAnyComplianceFilters(complianceFilter) && !drService.doesCacheHaveAnyOkData()) {
-            errors.add(msgUtil.getMessage("search.complianceFilter.unavailable"));
-        }
         errors.addAll(getNonConformityOperatorErrors(complianceFilter));
         errors.addAll(getNonConformitySearchOptionsErrors(complianceFilter));
         return errors;
-    }
-
-    private boolean hasAnyComplianceFilters(ComplianceSearchFilter complianceFilter) {
-        return complianceFilter != null
-                && (complianceFilter.getHasHadComplianceActivity() != null
-                    || (complianceFilter.getNonConformityOptions() != null && complianceFilter.getNonConformityOptions().size() > 0)
-                    || complianceFilter.getNonConformityOptionsOperator() != null);
     }
 
     private Set<String> getNonConformityOperatorErrors(ComplianceSearchFilter complianceFilter) {

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/search/SearchRequestValidatorTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/search/SearchRequestValidatorTest.java
@@ -1005,7 +1005,7 @@ public class SearchRequestValidatorTest {
     }
 
     @Test
-    public void validate_hasHadComplianceFilterNotNullDirectReviewsNotAvailable_addsError() {
+    public void validate_hasHadComplianceFilterNotNullDirectReviewsNotAvailable_noError() {
         Mockito.when(drService.doesCacheHaveAnyOkData()).thenReturn(false);
 
         SearchRequest request = SearchRequest.builder()
@@ -1018,14 +1018,13 @@ public class SearchRequestValidatorTest {
         try {
             validator.validate(request);
         } catch (ValidationException ex) {
-            assertTrue(ex.getErrorMessages().contains(DIRECT_REVIEWS_UNAVAILABLE));
+            fail("Should not execute.");
             return;
         }
-        fail("Should not execute.");
     }
 
     @Test
-    public void validate_hasNonConformityOptionsDirectReviewsNotAvailable_addsError() {
+    public void validate_hasNonConformityOptionsDirectReviewsNotAvailable_noError() {
         Mockito.when(drService.doesCacheHaveAnyOkData()).thenReturn(false);
 
         SearchRequest request = SearchRequest.builder()
@@ -1038,14 +1037,13 @@ public class SearchRequestValidatorTest {
         try {
             validator.validate(request);
         } catch (ValidationException ex) {
-            assertTrue(ex.getErrorMessages().contains(DIRECT_REVIEWS_UNAVAILABLE));
+            fail("Should not execute.");
             return;
         }
-        fail("Should not execute.");
     }
 
     @Test
-    public void validate_hasNonConformityOptionsOperatorDirectReviewsNotAvailable_addsError() {
+    public void validate_hasNonConformityOptionsOperatorDirectReviewsNotAvailable_noError() {
         Mockito.when(drService.doesCacheHaveAnyOkData()).thenReturn(false);
 
         SearchRequest request = SearchRequest.builder()
@@ -1058,10 +1056,9 @@ public class SearchRequestValidatorTest {
         try {
             validator.validate(request);
         } catch (ValidationException ex) {
-            assertTrue(ex.getErrorMessages().contains(DIRECT_REVIEWS_UNAVAILABLE));
+            fail("Should not execute.");
             return;
         }
-        fail("Should not execute.");
     }
 
     @Test


### PR DESCRIPTION
The /search/v* endpoints returned a 400 error if a user requested compliance filtering when Jira was unavailable but that was not a good strategy. Instead we will return 0 results if the user sends in compliance filters. The API always returns a field letting a consumer know that direct reviews are unavailable.

[#OCD-4183]