### PR TITLE
build(deps): bump tomcat-catalina in /chpl/chpl-service

### DIFF
--- a/chpl/chpl-service/pom.xml
+++ b/chpl/chpl-service/pom.xml
@@ -320,7 +320,7 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
-            <version>8.5.9</version>
+            <version>8.5.86</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Bumps tomcat-catalina from 8.5.9 to 8.5.86.

---
updated-dependencies:
- dependency-name: org.apache.tomcat:tomcat-catalina dependency-type: direct:production ...