### PR TITLE
OCD-4298: Fix issue with Singular annotation and Redis serialization

### DIFF
--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/domain/CertifiedProductSearchDetails.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/domain/CertifiedProductSearchDetails.java
@@ -306,7 +306,7 @@ public class CertifiedProductSearchDetails implements Serializable {
      */
     @XmlElementWrapper(name = "targetedUsers", nillable = true, required = false)
     @XmlElement(name = "targetedUser")
-    @Singular
+    @Builder.Default
     private List<CertifiedProductTargetedUser> targetedUsers = new ArrayList<CertifiedProductTargetedUser>();
 
     /**

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/domain/CertifiedProductSearchDetails.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/domain/CertifiedProductSearchDetails.java
@@ -358,7 +358,7 @@ public class CertifiedProductSearchDetails implements Serializable {
      */
     @XmlElementWrapper(name = "certificationEvents", nillable = true, required = false)
     @XmlElement(name = "certificationEvent")
-    @Singular
+    @Builder.Default
     private List<CertificationStatusEvent> certificationEvents = new ArrayList<CertificationStatusEvent>();
 
     /**

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/domain/CertifiedProductSearchDetails.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/domain/CertifiedProductSearchDetails.java
@@ -174,7 +174,7 @@ public class CertifiedProductSearchDetails implements Serializable {
      */
     @XmlElementWrapper(name = "testingLabs", nillable = true, required = false)
     @XmlElement(name = "testingLab")
-    @Singular
+    @Builder.Default
     private List<CertifiedProductTestingLab> testingLabs = new ArrayList<CertifiedProductTestingLab>();
 
     @XmlTransient

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/domain/CertifiedProductTargetedUser.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/domain/CertifiedProductTargetedUser.java
@@ -7,7 +7,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.springframework.util.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/domain/InheritedCertificationStatus.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/domain/InheritedCertificationStatus.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.Singular;
 
 @XmlType(namespace = "http://chpl.healthit.gov/listings")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -57,7 +56,7 @@ public class InheritedCertificationStatus implements Serializable {
      */
     @XmlElementWrapper(name = "parents", nillable = true, required = false)
     @XmlElement(name = "parent")
-    @Singular
+    @Builder.Default
     private List<CertifiedProduct> parents = new ArrayList<CertifiedProduct>();
 
     /**
@@ -65,7 +64,7 @@ public class InheritedCertificationStatus implements Serializable {
      */
     @XmlElementWrapper(name = "children", nillable = true, required = false)
     @XmlElement(name = "child")
-    @Singular
+    @Builder.Default
     private List<CertifiedProduct> children = new ArrayList<CertifiedProduct>();
 
 }

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/util/RedisUtil.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/util/RedisUtil.java
@@ -3,8 +3,6 @@ package gov.healthit.chpl.util;
 import java.util.List;
 
 import org.redisson.RedissonMap;
-import org.redisson.api.RedissonClient;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.Cache;
 import org.springframework.stereotype.Component;
 
@@ -13,12 +11,6 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 @Component
 public class RedisUtil {
-    private RedissonClient redissonClient;
-
-    @Autowired
-    public RedisUtil(RedissonClient redissonClient) {
-        this.redissonClient = redissonClient;
-    }
 
     public List<Long> getAllKeysForCacheAsLong(Cache cache) {
         RedissonMap<String, Object> map = (RedissonMap) cache.getNativeCache();

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/manager/CertifiedProductManagerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/manager/CertifiedProductManagerTest.java
@@ -8,6 +8,7 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -294,12 +295,12 @@ public class CertifiedProductManagerTest {
                         .owner(Developer.builder()
                                 .build())
                         .build())
-                .testingLab(CertifiedProductTestingLab.builder()
+                .testingLabs(Stream.of(CertifiedProductTestingLab.builder()
                         .id(1L)
                         .testingLabCode("04")
                         .testingLabId(1L)
                         .testingLabName("Drummond Group")
-                        .build())
+                        .build()).toList())
                 .version(ProductVersion.builder()
                         .id(1L)
                         .version("11.3")

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/manager/CertifiedProductManagerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/manager/CertifiedProductManagerTest.java
@@ -8,6 +8,7 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.Before;
@@ -250,14 +251,14 @@ public class CertifiedProductManagerTest {
                 .id(1L)
                 .certificationDate(cal1.getTime().getTime())
                 .certificationEdition(getCertificationEdition())
-                .certificationEvent(CertificationStatusEvent.builder()
+                .certificationEvents(Stream.of(CertificationStatusEvent.builder()
                         .eventDate(cal1.getTime().getTime())
                         .id(1L)
                         .status(CertificationStatus.builder()
                                 .id(1L)
                                 .name("Active")
                                 .build())
-                        .build())
+                        .build()).collect(Collectors.toList()))
                 .certifyingBody(getCertifyingBody())
                 .chplProductNumber("15.04.04.3046.Acel.11.01.0.190517")
                 .cqmResults(new ArrayList<CQMResultDetails>())

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/upload/listing/normalizer/IcsNormalizerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/upload/listing/normalizer/IcsNormalizerTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.stream.Stream;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -147,9 +148,9 @@ public class IcsNormalizerTest {
     public void normalize_icsParentsHaveIds_noChanges() {
         CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
                 .ics(InheritedCertificationStatus.builder()
-                        .parent(CertifiedProduct.builder()
+                        .parents(Stream.of(CertifiedProduct.builder()
                                 .id(1L)
-                                .build())
+                                .build()).toList())
                         .build())
                 .build();
         normalizer.normalize(listing);
@@ -163,9 +164,9 @@ public class IcsNormalizerTest {
     public void normalize_icsParentsMissingIds_getsData() {
         CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
                 .ics(InheritedCertificationStatus.builder()
-                        .parent(CertifiedProduct.builder()
+                        .parents(Stream.of(CertifiedProduct.builder()
                                 .chplProductNumber("15.04.04.2526.WEBe.06.00.1.210101")
-                                .build())
+                                .build()).toList())
                         .build())
                 .build();
         Mockito.when(cpDao.getByChplProductNumber(ArgumentMatchers.anyString()))
@@ -185,9 +186,9 @@ public class IcsNormalizerTest {
     public void normalize_icsParentsMissingIdsNoMatchingChplProductNumber_getsNoData() {
         CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
                 .ics(InheritedCertificationStatus.builder()
-                        .parent(CertifiedProduct.builder()
+                        .parents(Stream.of(CertifiedProduct.builder()
                                 .chplProductNumber("15.04.04.2526.WEBe.06.00.1.210101")
-                                .build())
+                                .build()).toList())
                         .build())
                 .build();
         Mockito.when(cpDao.getByChplProductNumber(ArgumentMatchers.anyString()))

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/validation/listing/reviewer/ConformanceMethodReviewerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/validation/listing/reviewer/ConformanceMethodReviewerTest.java
@@ -633,9 +633,9 @@ public class ConformanceMethodReviewerTest {
                 .certificationDate(DateUtil.toEpochMillis(LocalDate.parse("2022-06-02")))
                 .certificationEdition(get2015CertificationEdition())
                 .ics(InheritedCertificationStatus.builder()
-                        .parent(CertifiedProduct.builder()
+                        .parents(Stream.of(CertifiedProduct.builder()
                                 .id(1L)
-                                .build())
+                                .build()).toList())
                         .build())
                 .build();
         conformanceMethodReviewer.review(listing);
@@ -674,9 +674,9 @@ public class ConformanceMethodReviewerTest {
                 .certificationDate(DateUtil.toEpochMillis(LocalDate.parse("2022-06-02")))
                 .certificationEdition(get2015CertificationEdition())
                 .ics(InheritedCertificationStatus.builder()
-                        .parent(CertifiedProduct.builder()
+                        .parents(Stream.of(CertifiedProduct.builder()
                                 .id(1L)
-                                .build())
+                                .build()).toList())
                         .build())
                 .build();
         conformanceMethodReviewer.review(listing);
@@ -721,9 +721,9 @@ public class ConformanceMethodReviewerTest {
                 .certificationDate(DateUtil.toEpochMillis(LocalDate.parse("2022-06-02")))
                 .certificationEdition(get2015CertificationEdition())
                 .ics(InheritedCertificationStatus.builder()
-                        .parent(CertifiedProduct.builder()
+                        .parents(Stream.of(CertifiedProduct.builder()
                                 .id(1L)
-                                .build())
+                                .build()).toList())
                         .build())
                 .build();
         conformanceMethodReviewer.review(listing);
@@ -769,9 +769,9 @@ public class ConformanceMethodReviewerTest {
                 .certificationDate(DateUtil.toEpochMillis(LocalDate.parse("2022-06-02")))
                 .certificationEdition(get2015CertificationEdition())
                 .ics(InheritedCertificationStatus.builder()
-                        .parent(CertifiedProduct.builder()
+                        .parents(Stream.of(CertifiedProduct.builder()
                                 .id(1L)
-                                .build())
+                                .build()).toList())
                         .build())
                 .build();
         conformanceMethodReviewer.review(listing);

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/validation/listing/reviewer/FieldLengthReviewerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/validation/listing/reviewer/FieldLengthReviewerTest.java
@@ -468,10 +468,11 @@ public class FieldLengthReviewerTest {
 
     @Test
     public void review_shortTargetedUserName_noError() {
-        CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
-                .targetedUser(CertifiedProductTargetedUser.builder()
+        List<CertifiedProductTargetedUser> targetedUsers = Stream.of(CertifiedProductTargetedUser.builder()
                         .targetedUserName("short name")
-                        .build())
+                        .build()).toList();
+        CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
+                .targetedUsers(targetedUsers)
                 .build();
 
         reviewer.review(listing);
@@ -480,10 +481,12 @@ public class FieldLengthReviewerTest {
 
     @Test
     public void review_longTargetedUserName_hasError() {
+        List<CertifiedProductTargetedUser> targetedUsers = Stream.of(CertifiedProductTargetedUser.builder()
+                .targetedUserName(createStringLongerThan(300, "a"))
+                .build()).toList();
+
         CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
-                .targetedUser(CertifiedProductTargetedUser.builder()
-                        .targetedUserName(createStringLongerThan(300, "a"))
-                        .build())
+                .targetedUsers(targetedUsers)
                 .build();
 
         reviewer.review(listing);
@@ -493,13 +496,15 @@ public class FieldLengthReviewerTest {
 
     @Test
     public void review_oneShortAndOneLongTargetedUserName_hasError() {
+        List<CertifiedProductTargetedUser> targetedUsers = Stream.of(CertifiedProductTargetedUser.builder()
+                .targetedUserName(createStringLongerThan(300, "a"))
+                .build(),
+                CertifiedProductTargetedUser.builder()
+                .targetedUserName("short name")
+                .build()).toList();
+
         CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
-                .targetedUser(CertifiedProductTargetedUser.builder()
-                        .targetedUserName(createStringLongerThan(300, "a"))
-                        .build())
-                .targetedUser(CertifiedProductTargetedUser.builder()
-                        .targetedUserName("short name")
-                        .build())
+                .targetedUsers(targetedUsers)
                 .build();
 
         reviewer.review(listing);

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/validation/listing/reviewer/InheritanceComparisonReviewerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/validation/listing/reviewer/InheritanceComparisonReviewerTest.java
@@ -3,6 +3,9 @@ package gov.healthit.chpl.validation.listing.reviewer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.stream.Stream;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
@@ -62,12 +65,12 @@ public class InheritanceComparisonReviewerTest {
     public void review_emptyIcsChildrenInCurrentOrUpdated_noErrors() {
         CertifiedProductSearchDetails existingListing = CertifiedProductSearchDetails.builder()
                 .ics(InheritedCertificationStatus.builder()
-                        .clearChildren()
+                        .children(new ArrayList<CertifiedProduct>())
                         .build())
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .ics(InheritedCertificationStatus.builder()
-                        .clearChildren()
+                        .children(new ArrayList<CertifiedProduct>())
                         .build())
                 .build();
 
@@ -79,18 +82,18 @@ public class InheritanceComparisonReviewerTest {
     public void review_currentIcsEmptyChildrenUpdatedIcsOneChild_noErrors() {
         CertifiedProductSearchDetails existingListing = CertifiedProductSearchDetails.builder()
                 .ics(InheritedCertificationStatus.builder()
-                        .clearChildren()
+                        .children(new ArrayList<CertifiedProduct>())
                         .build())
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .ics(InheritedCertificationStatus.builder()
-                        .child(CertifiedProduct.builder()
+                        .children(Stream.of(CertifiedProduct.builder()
                                 .id(1L)
                                 .certificationDate(System.currentTimeMillis())
                                 .certificationStatus(CertificationStatusType.Active.getName())
                                 .curesUpdate(false)
                                 .chplProductNumber("CHP-12345")
-                                .build())
+                                .build()).toList())
                         .build())
                 .build();
 
@@ -102,24 +105,24 @@ public class InheritanceComparisonReviewerTest {
     public void review_currentIcsMatchesUpdatedIcsOneChild_noErrors() {
         CertifiedProductSearchDetails existingListing = CertifiedProductSearchDetails.builder()
                 .ics(InheritedCertificationStatus.builder()
-                        .child(CertifiedProduct.builder()
+                        .children(Stream.of(CertifiedProduct.builder()
                                 .id(1L)
                                 .certificationDate(System.currentTimeMillis())
                                 .certificationStatus(CertificationStatusType.Active.getName())
                                 .curesUpdate(false)
                                 .chplProductNumber("CHP-12345")
-                                .build())
+                                .build()).toList())
                         .build())
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .ics(InheritedCertificationStatus.builder()
-                        .child(CertifiedProduct.builder()
+                        .children(Stream.of(CertifiedProduct.builder()
                                 .id(1L)
                                 .certificationDate(System.currentTimeMillis())
                                 .certificationStatus(CertificationStatusType.Active.getName())
                                 .curesUpdate(false)
                                 .chplProductNumber("CHP-12345")
-                                .build())
+                                .build()).toList())
                         .build())
                 .build();
 
@@ -131,18 +134,18 @@ public class InheritanceComparisonReviewerTest {
     public void review_currentIcsOneChildUpdatedIcsEmptyChildren_hasError() {
         CertifiedProductSearchDetails existingListing = CertifiedProductSearchDetails.builder()
                 .ics(InheritedCertificationStatus.builder()
-                        .child(CertifiedProduct.builder()
+                        .children(Stream.of(CertifiedProduct.builder()
                                 .id(1L)
                                 .certificationDate(System.currentTimeMillis())
                                 .certificationStatus(CertificationStatusType.Active.getName())
                                 .curesUpdate(false)
                                 .chplProductNumber("CHP-12345")
-                                .build())
+                                .build()).toList())
                         .build())
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .ics(InheritedCertificationStatus.builder()
-                        .clearChildren()
+                        .children(new ArrayList<CertifiedProduct>())
                         .build())
                 .build();
 
@@ -155,24 +158,24 @@ public class InheritanceComparisonReviewerTest {
     public void review_currentIcsOneChildUpdatedIcsDifferentChild_hasError() {
         CertifiedProductSearchDetails existingListing = CertifiedProductSearchDetails.builder()
                 .ics(InheritedCertificationStatus.builder()
-                        .child(CertifiedProduct.builder()
+                        .children(Stream.of(CertifiedProduct.builder()
                                 .id(1L)
                                 .certificationDate(System.currentTimeMillis())
                                 .certificationStatus(CertificationStatusType.Active.getName())
                                 .curesUpdate(false)
                                 .chplProductNumber("CHP-12345")
-                                .build())
+                                .build()).toList())
                         .build())
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .ics(InheritedCertificationStatus.builder()
-                        .child(CertifiedProduct.builder()
+                        .children(Stream.of(CertifiedProduct.builder()
                                 .id(2L)
                                 .certificationDate(System.currentTimeMillis())
                                 .certificationStatus(CertificationStatusType.Active.getName())
                                 .curesUpdate(false)
                                 .chplProductNumber("CHP-12346")
-                                .build())
+                                .build()).toList())
                         .build())
                 .build();
 
@@ -185,31 +188,32 @@ public class InheritanceComparisonReviewerTest {
     public void review_currentIcsTwoChildrenUpdatedIcsOneChild_hasError() {
         CertifiedProductSearchDetails existingListing = CertifiedProductSearchDetails.builder()
                 .ics(InheritedCertificationStatus.builder()
-                        .child(CertifiedProduct.builder()
-                                .id(1L)
-                                .certificationDate(System.currentTimeMillis())
-                                .certificationStatus(CertificationStatusType.Active.getName())
-                                .curesUpdate(false)
-                                .chplProductNumber("CHP-12345")
-                                .build())
-                        .child(CertifiedProduct.builder()
-                                .id(2L)
-                                .certificationDate(System.currentTimeMillis())
-                                .certificationStatus(CertificationStatusType.Active.getName())
-                                .curesUpdate(false)
-                                .chplProductNumber("CHP-12346")
-                                .build())
+                        .children(Stream.of(
+                                CertifiedProduct.builder()
+                                    .id(1L)
+                                    .certificationDate(System.currentTimeMillis())
+                                    .certificationStatus(CertificationStatusType.Active.getName())
+                                    .curesUpdate(false)
+                                    .chplProductNumber("CHP-12345")
+                                    .build(),
+                                CertifiedProduct.builder()
+                                    .id(2L)
+                                    .certificationDate(System.currentTimeMillis())
+                                    .certificationStatus(CertificationStatusType.Active.getName())
+                                    .curesUpdate(false)
+                                    .chplProductNumber("CHP-12346")
+                                    .build()).toList())
                         .build())
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .ics(InheritedCertificationStatus.builder()
-                        .child(CertifiedProduct.builder()
+                        .children(Stream.of(CertifiedProduct.builder()
                                 .id(2L)
                                 .certificationDate(System.currentTimeMillis())
                                 .certificationStatus(CertificationStatusType.Active.getName())
                                 .curesUpdate(false)
                                 .chplProductNumber("CHP-12346")
-                                .build())
+                                .build()).toList())
                         .build())
                 .build();
 

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/validation/listing/reviewer/ListingStatusAndUserRoleReviewerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/validation/listing/reviewer/ListingStatusAndUserRoleReviewerTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -69,11 +71,11 @@ public class ListingStatusAndUserRoleReviewerTest {
 
         CertifiedProductSearchDetails origListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
                 .certificationResult(CertificationResult.builder()
                         .success(true)
                         .criterion(CertificationCriterion.builder()
@@ -95,7 +97,7 @@ public class ListingStatusAndUserRoleReviewerTest {
 
         CertifiedProductSearchDetails origListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
                 .certificationResult(CertificationResult.builder()
                         .success(true)
                         .criterion(CertificationCriterion.builder()
@@ -106,7 +108,7 @@ public class ListingStatusAndUserRoleReviewerTest {
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
                 .build();
         reviewer.review(origListing, updatedListing);
 
@@ -120,11 +122,11 @@ public class ListingStatusAndUserRoleReviewerTest {
 
         CertifiedProductSearchDetails origListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.SUSPENDED_BY_ACB))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.SUSPENDED_BY_ACB))
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.SUSPENDED_BY_ACB))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.SUSPENDED_BY_ACB))
                 .certificationResult(CertificationResult.builder()
                         .success(true)
                         .criterion(CertificationCriterion.builder()
@@ -146,7 +148,7 @@ public class ListingStatusAndUserRoleReviewerTest {
 
         CertifiedProductSearchDetails origListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.SUSPENDED_BY_ACB))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.SUSPENDED_BY_ACB))
                 .certificationResult(CertificationResult.builder()
                         .success(true)
                         .criterion(CertificationCriterion.builder()
@@ -157,7 +159,7 @@ public class ListingStatusAndUserRoleReviewerTest {
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.SUSPENDED_BY_ACB))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.SUSPENDED_BY_ACB))
                 .build();
 
         reviewer.review(origListing, updatedListing);
@@ -172,11 +174,11 @@ public class ListingStatusAndUserRoleReviewerTest {
 
         CertifiedProductSearchDetails origListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.RETIRED))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.RETIRED))
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.RETIRED))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.RETIRED))
                 .certificationResult(CertificationResult.builder()
                         .success(true)
                         .criterion(CertificationCriterion.builder()
@@ -198,7 +200,7 @@ public class ListingStatusAndUserRoleReviewerTest {
 
         CertifiedProductSearchDetails origListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.RETIRED))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.RETIRED))
                 .certificationResult(CertificationResult.builder()
                         .success(true)
                         .criterion(CertificationCriterion.builder()
@@ -209,7 +211,7 @@ public class ListingStatusAndUserRoleReviewerTest {
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.RETIRED))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.RETIRED))
                 .build();
 
         reviewer.review(origListing, updatedListing);
@@ -224,13 +226,13 @@ public class ListingStatusAndUserRoleReviewerTest {
 
         CertifiedProductSearchDetails origListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(
-                        getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.WITHDRAWN_BY_DEVELOPER))
+                .certificationEvents(
+                        getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.WITHDRAWN_BY_DEVELOPER))
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(
-                        getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.WITHDRAWN_BY_DEVELOPER))
+                .certificationEvents(
+                        getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.WITHDRAWN_BY_DEVELOPER))
                 .certificationResult(CertificationResult.builder()
                         .success(true)
                         .criterion(CertificationCriterion.builder()
@@ -252,8 +254,8 @@ public class ListingStatusAndUserRoleReviewerTest {
 
         CertifiedProductSearchDetails origListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(
-                        getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.WITHDRAWN_BY_DEVELOPER))
+                .certificationEvents(
+                        getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.WITHDRAWN_BY_DEVELOPER))
                 .certificationResult(CertificationResult.builder()
                         .success(true)
                         .criterion(CertificationCriterion.builder()
@@ -264,8 +266,8 @@ public class ListingStatusAndUserRoleReviewerTest {
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(
-                        getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.WITHDRAWN_BY_DEVELOPER))
+                .certificationEvents(
+                        getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.WITHDRAWN_BY_DEVELOPER))
                 .build();
 
         reviewer.review(origListing, updatedListing);
@@ -280,12 +282,12 @@ public class ListingStatusAndUserRoleReviewerTest {
 
         CertifiedProductSearchDetails origListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
-                .certificationEvent(getCertificationStatusEvent(1L, "02/01/2020", CertificationStatusProvider.RETIRED))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
+                .certificationEvents(getCertificationStatusEvents(1L, "02/01/2020", CertificationStatusProvider.RETIRED))
                 .certificationResult(CertificationResult.builder()
                         .success(true)
                         .criterion(CertificationCriterion.builder()
@@ -307,7 +309,7 @@ public class ListingStatusAndUserRoleReviewerTest {
 
         CertifiedProductSearchDetails origListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
                 .certificationResult(CertificationResult.builder()
                         .success(true)
                         .criterion(CertificationCriterion.builder()
@@ -318,8 +320,8 @@ public class ListingStatusAndUserRoleReviewerTest {
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
-                .certificationEvent(getCertificationStatusEvent(1L, "02/01/2020", CertificationStatusProvider.RETIRED))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
+                .certificationEvents(getCertificationStatusEvents(1L, "02/01/2020", CertificationStatusProvider.RETIRED))
                 .build();
 
         reviewer.review(origListing, updatedListing);
@@ -335,14 +337,14 @@ public class ListingStatusAndUserRoleReviewerTest {
 
         CertifiedProductSearchDetails origListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
-                .certificationEvent(getCertificationStatusEvent(1L, "02/01/2020", CertificationStatusProvider.RETIRED))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
+                .certificationEvents(getCertificationStatusEvents(1L, "02/01/2020", CertificationStatusProvider.RETIRED))
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
-                .certificationEvent(getCertificationStatusEvent(1L, "02/01/2020", CertificationStatusProvider.RETIRED))
-                .certificationEvent(getCertificationStatusEvent(1L, "03/01/2020", CertificationStatusProvider.ACTIVE))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
+                .certificationEvents(getCertificationStatusEvents(1L, "02/01/2020", CertificationStatusProvider.RETIRED))
+                .certificationEvents(getCertificationStatusEvents(1L, "03/01/2020", CertificationStatusProvider.ACTIVE))
                 .certificationResult(CertificationResult.builder()
                         .success(true)
                         .criterion(CertificationCriterion.builder()
@@ -365,8 +367,8 @@ public class ListingStatusAndUserRoleReviewerTest {
 
         CertifiedProductSearchDetails origListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
-                .certificationEvent(getCertificationStatusEvent(1L, "02/01/2020", CertificationStatusProvider.RETIRED))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
+                .certificationEvents(getCertificationStatusEvents(1L, "02/01/2020", CertificationStatusProvider.RETIRED))
                 .certificationResult(CertificationResult.builder()
                         .success(true)
                         .criterion(CertificationCriterion.builder()
@@ -377,9 +379,9 @@ public class ListingStatusAndUserRoleReviewerTest {
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
-                .certificationEvent(getCertificationStatusEvent(1L, "02/01/2020", CertificationStatusProvider.RETIRED))
-                .certificationEvent(getCertificationStatusEvent(1L, "03/01/2020", CertificationStatusProvider.ACTIVE))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.ACTIVE))
+                .certificationEvents(getCertificationStatusEvents(1L, "02/01/2020", CertificationStatusProvider.RETIRED))
+                .certificationEvents(getCertificationStatusEvents(1L, "03/01/2020", CertificationStatusProvider.ACTIVE))
                 .build();
 
         reviewer.review(origListing, updatedListing);
@@ -395,7 +397,7 @@ public class ListingStatusAndUserRoleReviewerTest {
 
         CertifiedProductSearchDetails origListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.RETIRED))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.RETIRED))
                 .certificationResult(CertificationResult.builder()
                         .success(true)
                         .criterion(CertificationCriterion.builder()
@@ -406,7 +408,7 @@ public class ListingStatusAndUserRoleReviewerTest {
                 .build();
         CertifiedProductSearchDetails updatedListing = CertifiedProductSearchDetails.builder()
                 .id(1L)
-                .certificationEvent(getCertificationStatusEvent(1L, "01/01/2020", CertificationStatusProvider.RETIRED))
+                .certificationEvents(getCertificationStatusEvents(1L, "01/01/2020", CertificationStatusProvider.RETIRED))
                 .certificationResult(CertificationResult.builder()
                         .success(true)
                         .criterion(CertificationCriterion.builder()
@@ -421,12 +423,12 @@ public class ListingStatusAndUserRoleReviewerTest {
         assertEquals(1, updatedListing.getErrorMessages().size());
     }
 
-    private CertificationStatusEvent getCertificationStatusEvent(Long eventId, String date, Long statusId)
+    private List<CertificationStatusEvent> getCertificationStatusEvents(Long eventId, String date, Long statusId)
             throws ParseException {
-        return CertificationStatusEvent.builder()
+        return Stream.of(CertificationStatusEvent.builder()
                 .id(eventId)
                 .eventDate(sdf.parse(date).getTime())
                 .status(certificationStatusProvider.get(statusId))
-                .build();
+                .build()).toList();
     }
 }

--- a/chpl/chpl-service/src/test/java/gov/healthit/chpl/validation/listing/reviewer/duplicate/IcsSourceDuplicateReviewerTest.java
+++ b/chpl/chpl-service/src/test/java/gov/healthit/chpl/validation/listing/reviewer/duplicate/IcsSourceDuplicateReviewerTest.java
@@ -2,6 +2,9 @@ package gov.healthit.chpl.validation.listing.reviewer.duplicate;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.ArrayList;
+import java.util.stream.Stream;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
@@ -30,18 +33,18 @@ public class IcsSourceDuplicateReviewerTest {
 
     @Test
     public void review_duplicateExists_warningFoundAndDuplicateRemoved() {
-        CertifiedProductSearchDetails listing = new CertifiedProductSearchDetails();
-        listing.setIcs(new InheritedCertificationStatus());
-
-        CertifiedProduct ics1 = new CertifiedProduct();
-        ics1.setChplProductNumber("Chpl1");
-
-        CertifiedProduct ics2 = new CertifiedProduct();
-        ics2.setChplProductNumber("Chpl1");
-
-        listing.getIcs().getParents().add(ics1);
-        listing.getIcs().getParents().add(ics2);
-
+        CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
+                .ics(InheritedCertificationStatus.builder()
+                        .inherits(true)
+                        .parents(Stream.of(
+                                CertifiedProduct.builder()
+                                    .chplProductNumber("Chpl1")
+                                    .build(),
+                                CertifiedProduct.builder()
+                                    .chplProductNumber("Chpl1")
+                                    .build()).toList())
+                        .build())
+                .build();
         reviewer.review(listing);
 
         assertEquals(1, listing.getWarningMessages().size());
@@ -53,18 +56,18 @@ public class IcsSourceDuplicateReviewerTest {
 
     @Test
     public void review_noDuplicates_noWarning() {
-        CertifiedProductSearchDetails listing = new CertifiedProductSearchDetails();
-        listing.setIcs(new InheritedCertificationStatus());
-
-        CertifiedProduct ics1 = new CertifiedProduct();
-        ics1.setChplProductNumber("Chpl1");
-
-        CertifiedProduct ics2 = new CertifiedProduct();
-        ics2.setChplProductNumber("Chpl2");
-
-        listing.getIcs().getParents().add(ics1);
-        listing.getIcs().getParents().add(ics2);
-
+        CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
+                .ics(InheritedCertificationStatus.builder()
+                        .inherits(true)
+                        .parents(Stream.of(
+                                CertifiedProduct.builder()
+                                    .chplProductNumber("Chpl1")
+                                    .build(),
+                                CertifiedProduct.builder()
+                                    .chplProductNumber("Chpl2")
+                                    .build()).toList())
+                        .build())
+                .build();
         reviewer.review(listing);
 
         assertEquals(0, listing.getWarningMessages().size());
@@ -73,9 +76,12 @@ public class IcsSourceDuplicateReviewerTest {
 
     @Test
     public void review_emptyIcsSource_noWarning() {
-        CertifiedProductSearchDetails listing = new CertifiedProductSearchDetails();
-        listing.setIcs(new InheritedCertificationStatus());
-        listing.getIcs().getParents().clear();
+        CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
+                .ics(InheritedCertificationStatus.builder()
+                        .inherits(true)
+                        .parents(new ArrayList<CertifiedProduct>())
+                        .build())
+                .build();
 
         reviewer.review(listing);
 
@@ -85,25 +91,24 @@ public class IcsSourceDuplicateReviewerTest {
 
     @Test
     public void review_duplicateExistsInLargeSet_warningFoundAndDuplicateRemoved() {
-        CertifiedProductSearchDetails listing = new CertifiedProductSearchDetails();
-        listing.setIcs(new InheritedCertificationStatus());
-
-        CertifiedProduct ics1 = new CertifiedProduct();
-        ics1.setChplProductNumber("Chpl1");
-
-        CertifiedProduct ics2 = new CertifiedProduct();
-        ics2.setChplProductNumber("Chpl2");
-
-        CertifiedProduct ics3 = new CertifiedProduct();
-        ics3.setChplProductNumber("Chpl1");
-
-        CertifiedProduct ics4 = new CertifiedProduct();
-        ics4.setChplProductNumber("Chpl4");
-
-        listing.getIcs().getParents().add(ics1);
-        listing.getIcs().getParents().add(ics2);
-        listing.getIcs().getParents().add(ics3);
-        listing.getIcs().getParents().add(ics4);
+        CertifiedProductSearchDetails listing = CertifiedProductSearchDetails.builder()
+                .ics(InheritedCertificationStatus.builder()
+                        .inherits(true)
+                        .parents(Stream.of(
+                                CertifiedProduct.builder()
+                                    .chplProductNumber("Chpl1")
+                                    .build(),
+                                CertifiedProduct.builder()
+                                    .chplProductNumber("Chpl2")
+                                    .build(),
+                                CertifiedProduct.builder()
+                                    .chplProductNumber("Chpl1")
+                                    .build(),
+                                CertifiedProduct.builder()
+                                    .chplProductNumber("Chpl4")
+                                    .build()).toList())
+                        .build())
+                .build();
 
         reviewer.review(listing);
 


### PR DESCRIPTION
The upload file goes into the system fine and the resulting pending listing details are cached in Redis. When the application requests the listing details of the pending listing by ID, we try to retrieve the pending listing from Redis. It's configured with the Kryo5 serializer and that internally is using an unmodifiable collection for the objects annotated with @ Singular. So if there is more than one thing in that collection, the serialization fails. We need to keep this in mind for any future things we decide to cache. I removed the @ Singular annotation from everywhere it was present in our listing details objects,.. except for Certification Results. Not sure why that one does not break, and if I remove the annotation from there I need to spend time fixing 600+ unit test compilation errors. The annotation is also still used in Change Requests and a few other places, and those are not cached currently so it's not an issue.