### PR TITLE
build: add missing POM entry

### DIFF
--- a/chpl/chpl-api/pom.xml
+++ b/chpl/chpl-api/pom.xml
@@ -106,6 +106,13 @@
             </exclusions>
         </dependency>
 
+        <!-- Rate limiting -->
+        <dependency>
+            <groupId>com.github.vladimir-bukhtoyarov</groupId>
+            <artifactId>bucket4j-core</artifactId>
+            <version>7.6.0</version>
+        </dependency>
+
         <!-- provided dependencies -->
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -114,13 +121,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Rate limiting -->
-        <dependency>
-            <groupId>com.github.vladimir-bukhtoyarov</groupId>
-            <artifactId>bucket4j-core</artifactId>
-            <version>7.6.0</version>
-        </dependency>
-        
         <!-- test dependencies -->
         <dependency>
             <groupId>gov.healthit.chpl</groupId>


### PR DESCRIPTION
Since I had already updated the `staging` branch, I simply moved the Bucket4j entry to create this PR.

OCD-4363