### PR TITLE
fix: Add null check to DateUtil to handle null certification date

### DIFF
--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/util/DateUtil.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/util/DateUtil.java
@@ -49,6 +49,10 @@ public final class DateUtil {
     }
 
     public static boolean isDateBetweenInclusive(Pair<LocalDate, LocalDate> dateRange, LocalDate dateToCheck) {
+        if (dateToCheck == null) {
+            return false;
+        }
+
         Pair<LocalDate, LocalDate> modifiedDateRange = Pair.of(dateRange);
         if (modifiedDateRange.getLeft() == null) {
             modifiedDateRange = Pair.of(LocalDate.MIN, modifiedDateRange.getRight());


### PR DESCRIPTION
The new BaselineStandardsReviewer is comparing a standard start/end date to a listing certification date. We had a listing in AQA upload that is formatted so poorly that it does not even have a certification date. Some tests were failing given the null value in that field.

[#OCD-4408]