### PR TITLE
OCD-4667: Remove reference to lastModifiedUser from CPSummary

### DIFF
--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/dto/CertifiedProductSummaryDTO.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/dto/CertifiedProductSummaryDTO.java
@@ -42,7 +42,6 @@ public class CertifiedProductSummaryDTO implements Serializable {
     private String mandatoryDisclosures;
     private Date creationDate;
     private Date lastModifiedDate;
-    private String lastModifiedUser;
     private String rwtPlansUrl;
     private LocalDate rwtPlansCheckDate;
     private String rwtResultsUrl;
@@ -82,7 +81,6 @@ public class CertifiedProductSummaryDTO implements Serializable {
         this.mandatoryDisclosures = entity.getMandatoryDisclosures();
         this.creationDate = entity.getCreationDate();
         this.lastModifiedDate = entity.getLastModifiedDate();
-        this.lastModifiedUser = entity.getLastModifiedUser().toString();
         this.rwtPlansUrl = entity.getRwtPlansUrl();
         this.rwtPlansCheckDate = entity.getRwtPlansCheckDate();
         this.rwtResultsUrl = entity.getRwtResultsUrl();


### PR DESCRIPTION
The last modified user is sometimes null now that we have SSO users and the reference to that field was failing when it was null. It turns out we aren't using it anywhere so the simplest thing was just to get rid of it.

[#OCD-4667]