### PR TITLE
fix!: Use certification date from upload to create active cert event

### DIFF
--- a/chpl/chpl-resources/src/main/resources/errors.properties
+++ b/chpl/chpl-resources/src/main/resources/errors.properties
@@ -323,7 +323,7 @@ listing.criteria.standardUnavailable=The Standard %s on the criterion %s is unav
 listing.criteria.standardNotSelected=The criterion %s requires Standard %s.
 listing.criteria.standardGroupNotSelected=In Criteria %s, at least one of the following Standards must be selected: %s
 listing.criteria.standardNotRemovable=The Standard %s on the criterion %s can not be removed.
-listing.criteria.baselineStandardsAdded=Required standards were added to %s.
+listing.criteria.baselineStandardsAdded=Standards required on %s were added to %s.
 
 #conformance method / test procedure errors
 listing.criteria.testProcedureNotApplicable=Test Procedures are not applicable for the criterion %s. They have been removed.

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/domain/CertificationStatusEvent.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/domain/CertificationStatusEvent.java
@@ -76,7 +76,9 @@ public class CertificationStatusEvent implements Serializable {
     @Deprecated
     public void setEventDate(Long eventDate) {
         this.eventDate = eventDate;
-        this.eventDay = DateUtil.toLocalDate(eventDate);
+        if (eventDate != null) {
+            this.eventDay = DateUtil.toLocalDate(eventDate);
+        }
     }
 
     public void setEventDay(LocalDate eventDay) {

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/ListingUploadManager.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/ListingUploadManager.java
@@ -218,7 +218,10 @@ public class ListingUploadManager {
         LOGGER.debug("Converting listing upload into CertifiedProductSearchDetails object");
         CertifiedProductSearchDetails listing = listingDetailsHandler.parseAsListing(headingRecord, allListingRecords);
         LOGGER.debug("Converted listing upload into CertifiedProductSearchDetails object");
-        listingNormalizer.normalize(listing, List.of(baselineStandardAsOfCertificationDayNormalizer, baselineStandardAsOfTodayNormalizer));
+
+        listingNormalizer.normalize(listing, List.of(
+                baselineStandardAsOfCertificationDayNormalizer,  // have to re-add older baseline standards that users might not put in their file
+                baselineStandardAsOfTodayNormalizer)); // and add the most current baseline standards we've agreed to always add for users
         LOGGER.debug("Normalized listing upload");
         return listing;
     }

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/handler/ListingDetailsUploadHandler.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/handler/ListingDetailsUploadHandler.java
@@ -6,17 +6,22 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.csv.CSVRecord;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import gov.healthit.chpl.domain.CertificationResult;
+import gov.healthit.chpl.domain.CertificationStatus;
+import gov.healthit.chpl.domain.CertificationStatusEvent;
 import gov.healthit.chpl.domain.CertifiedProductSearchDetails;
 import gov.healthit.chpl.domain.CertifiedProductTestingLab;
 import gov.healthit.chpl.domain.Product;
 import gov.healthit.chpl.domain.ProductVersion;
 import gov.healthit.chpl.domain.TestingLab;
+import gov.healthit.chpl.entity.CertificationStatusType;
 import gov.healthit.chpl.upload.listing.ListingUploadHandlerUtil;
 import gov.healthit.chpl.upload.listing.ListingUploadHeadingUtil.Heading;
 import jakarta.validation.ValidationException;
@@ -95,6 +100,10 @@ public class ListingDetailsUploadHandler {
             .build();
 
         listing.setSed(sedUploadHandler.parseAsSed(headingRecord, listingRecords, listing));
+        listing.setCertificationEvents(Stream.of(CertificationStatusEvent.builder()
+                .eventDate(listing.getCertificationDate())
+                .status(CertificationStatus.builder().name(CertificationStatusType.Active.getName()).build())
+                .build()).collect(Collectors.toList()));
 
         //add cert result data
         List<CertificationResult> certResultList = new ArrayList<CertificationResult>();

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/BaselineStandardNormalizer.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/BaselineStandardNormalizer.java
@@ -45,6 +45,7 @@ public abstract class BaselineStandardNormalizer implements CertificationResultL
 
             if (!CollectionUtils.isEmpty(criteriaWithBaselineStandardsAdded)) {
                 listing.addWarningMessage(msgUtil.getMessage("listing.criteria.baselineStandardsAdded",
+                        getStandardsCheckDate(listing),
                         Util.joinListGrammatically(criteriaWithBaselineStandardsAdded.stream()
                                 .map(criterion -> Util.formatCriteriaNumber(criterion))
                                 .collect(Collectors.toList()), "and")));


### PR DESCRIPTION
The "Baseline Standards As Of Today" normalizer is coded to only run if the listing is Active. Without any certification status events, which we were previously not interpreting from the upload file, the normalizer was not running and not adding any missing baseline standards that would be required today.

[#OCD-4786]