### PR TITLE
fix!: Stop adding baseline standards valid on cert date

### DIFF
--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/ListingUploadManager.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/ListingUploadManager.java
@@ -220,8 +220,7 @@ public class ListingUploadManager {
         LOGGER.debug("Converted listing upload into CertifiedProductSearchDetails object");
 
         listingNormalizer.normalize(listing, List.of(
-                baselineStandardAsOfCertificationDayNormalizer,  // have to re-add older baseline standards that users might not put in their file
-                baselineStandardAsOfTodayNormalizer)); // and add the most current baseline standards we've agreed to always add for users
+                baselineStandardAsOfTodayNormalizer)); // add the most current baseline standards we've agreed to always add for users
         LOGGER.debug("Normalized listing upload");
         return listing;
     }

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/AdditionalSoftwareNormalizer.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/AdditionalSoftwareNormalizer.java
@@ -27,7 +27,7 @@ public class AdditionalSoftwareNormalizer {
         if (listing.getCertificationResults() != null && listing.getCertificationResults().size() > 0) {
             clearDataForUnattestedCriteria(listing);
             listing.getCertificationResults().stream()
-                .forEach(certResult -> populateAdditionalSoftwareIds(certResult.getAdditionalSoftware()));
+                .forEach(certResult -> normalize(certResult.getAdditionalSoftware()));
         }
     }
 
@@ -38,11 +38,29 @@ public class AdditionalSoftwareNormalizer {
             .forEach(unattestedCertResult -> unattestedCertResult.getAdditionalSoftware().clear());
     }
 
-    private void populateAdditionalSoftwareIds(List<CertificationResultAdditionalSoftware> additionalSoftwares) {
+    private void normalize(List<CertificationResultAdditionalSoftware> additionalSoftwares) {
         if (additionalSoftwares != null && additionalSoftwares.size() > 0) {
+            additionalSoftwares.stream()
+                .forEach(additionalSoftware -> setEmptyStringFieldsToNull(additionalSoftware));
+
             additionalSoftwares.stream()
                 .filter(additionalSoftware -> hasListingAsAdditionalSoftware(additionalSoftware))
                 .forEach(additionalSoftware -> populateAdditionalSoftwareId(additionalSoftware));
+        }
+    }
+
+    private void setEmptyStringFieldsToNull(CertificationResultAdditionalSoftware additionalSoftware) {
+        if (StringUtils.isEmpty(additionalSoftware.getGrouping())) {
+            additionalSoftware.setGrouping(null);
+        }
+        if (StringUtils.isEmpty(additionalSoftware.getJustification())) {
+            additionalSoftware.setJustification(null);
+        }
+        if (StringUtils.isEmpty(additionalSoftware.getVersion())) {
+            additionalSoftware.setVersion(null);
+        }
+        if (StringUtils.isEmpty(additionalSoftware.getName())) {
+            additionalSoftware.setName(null);
         }
     }
 

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/CertificationResultNormalizer.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/CertificationResultNormalizer.java
@@ -64,6 +64,9 @@ public class CertificationResultNormalizer {
     }
 
     public void normalize(CertifiedProductSearchDetails listing, List<CertificationResultLevelNormalizer> additionalNormalizers) {
+        listing.getCertificationResults().stream()
+            .forEach(certResult -> setEmptyStringFieldsToNull(certResult));
+
         removeCertificationResultsWithNullCriterion(listing);
         removeCertificationResultsForDuplicateCriteria(listing);
 
@@ -148,6 +151,30 @@ public class CertificationResultNormalizer {
                     && BooleanUtils.isTrue(certResult.getSuccess())
                     && certResultRules.hasCertOption(certResult.getCriterion().getId(), CertificationResultRules.SED))
             .forEach(certResult -> certResult.setSed(true));
+    }
+
+    private void setEmptyStringFieldsToNull(CertificationResult cr) {
+        if (StringUtils.isEmpty(cr.getApiDocumentation())) {
+            cr.setApiDocumentation(null);
+        }
+        if (StringUtils.isEmpty(cr.getDocumentationUrl())) {
+            cr.setDocumentationUrl(null);
+        }
+        if (StringUtils.isEmpty(cr.getExportDocumentation())) {
+            cr.setExportDocumentation(null);
+        }
+        if (StringUtils.isEmpty(cr.getPrivacySecurityFramework())) {
+            cr.setPrivacySecurityFramework(null);
+        }
+        if (StringUtils.isEmpty(cr.getRiskManagementSummaryInformation())) {
+            cr.setRiskManagementSummaryInformation(null);
+        }
+        if (StringUtils.isEmpty(cr.getServiceBaseUrlList())) {
+            cr.setServiceBaseUrlList(null);
+        }
+        if (StringUtils.isEmpty(cr.getUseCases())) {
+            cr.setUseCases(null);
+        }
     }
 
     @NoArgsConstructor

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/ConformanceMethodNormalizer.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/ConformanceMethodNormalizer.java
@@ -39,7 +39,7 @@ public class ConformanceMethodNormalizer {
         if (!CollectionUtils.isEmpty(listing.getCertificationResults())) {
             clearDataForUnattestedCriteria(listing);
             listing.getCertificationResults().stream()
-                .forEach(certResult -> fillInConformanceMethodData(listing, certResult));
+                .forEach(certResult -> normalize(listing, certResult));
         }
     }
 
@@ -55,9 +55,19 @@ public class ConformanceMethodNormalizer {
             .forEach(unattestedCertResult -> unattestedCertResult.getTestProcedures().clear());
     }
 
-    private void fillInConformanceMethodData(CertifiedProductSearchDetails listing, CertificationResult certResult) {
+    private void normalize(CertifiedProductSearchDetails listing, CertificationResult certResult) {
+        if (!CollectionUtils.isEmpty(certResult.getConformanceMethods())) {
+            certResult.getConformanceMethods().stream()
+                .forEach(crcm -> setEmptyStringFieldsToNull(crcm));
+        }
         populateConformanceMethodIds(certResult.getCriterion(), certResult.getConformanceMethods());
         populateConformanceMethodRemovalDates(certResult.getCriterion(), certResult.getConformanceMethods());
+    }
+
+    private void setEmptyStringFieldsToNull(CertificationResultConformanceMethod crcm) {
+        if (StringUtils.isEmpty(crcm.getConformanceMethodVersion())) {
+            crcm.setConformanceMethodVersion(null);
+        }
     }
 
     private void populateConformanceMethodIds(CertificationCriterion criterion, List<CertificationResultConformanceMethod> conformanceMethods) {

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/QmsStandardNormalizer.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/QmsStandardNormalizer.java
@@ -25,8 +25,22 @@ public class QmsStandardNormalizer {
     public void normalize(CertifiedProductSearchDetails listing) {
         if (listing.getQmsStandards() != null && listing.getQmsStandards().size() > 0) {
             listing.getQmsStandards().stream()
-                .forEach(qmsStandard -> populateQmsStandardId(qmsStandard));
+                .forEach(qmsStandard -> normalize(qmsStandard));
             findFuzzyMatchesForUnknownStandards(listing);
+        }
+    }
+
+    private void normalize(CertifiedProductQmsStandard qmsStandard) {
+        setEmptyStringFieldsToNull(qmsStandard);
+        populateQmsStandardId(qmsStandard);
+    }
+
+    private void setEmptyStringFieldsToNull(CertifiedProductQmsStandard qmsStandard) {
+        if (StringUtils.isEmpty(qmsStandard.getApplicableCriteria())) {
+            qmsStandard.setApplicableCriteria(null);
+        }
+        if (StringUtils.isEmpty(qmsStandard.getQmsModification())) {
+            qmsStandard.setQmsModification(null);
         }
     }
 

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/TestDataNormalizer.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/TestDataNormalizer.java
@@ -41,7 +41,21 @@ public class TestDataNormalizer {
             List<CertificationResultTestData> testDatas) {
         if (testDatas != null && testDatas.size() > 0) {
             testDatas.stream()
-                .forEach(testData -> populateTestDataId(criterion, testData));
+                .forEach(testData -> normalize(criterion, testData));
+        }
+    }
+
+    private void normalize(CertificationCriterion criterion, CertificationResultTestData testData) {
+        setEmptyStringFieldsToNull(testData);
+        populateTestDataId(criterion, testData);
+    }
+
+    private void setEmptyStringFieldsToNull(CertificationResultTestData testData) {
+        if (StringUtils.isEmpty(testData.getAlteration())) {
+            testData.setAlteration(null);
+        }
+        if (StringUtils.isEmpty(testData.getVersion())) {
+            testData.setVersion(null);
         }
     }
 

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/TestToolNormalizer.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/TestToolNormalizer.java
@@ -31,15 +31,7 @@ public class TestToolNormalizer {
         if (!CollectionUtils.isEmpty(listing.getCertificationResults())) {
             clearDataForUnattestedCriteria(listing);
             listing.getCertificationResults().stream()
-                .forEach(certResult -> fillInTestToolData(certResult));
-        }
-    }
-
-    @Transactional
-    public void normalize(List<CertificationResultTestTool> testTools) {
-        if (!CollectionUtils.isEmpty(testTools)) {
-            testTools.stream()
-                    .forEach(certResultTestTool -> populateTestToolId(certResultTestTool));
+                .forEach(certResult -> normalize(certResult));
         }
     }
 
@@ -50,8 +42,18 @@ public class TestToolNormalizer {
             .forEach(unattestedCertResult -> unattestedCertResult.getTestToolsUsed().clear());
     }
 
-    private void fillInTestToolData(CertificationResult certResult) {
+    private void normalize(CertificationResult certResult) {
+        if (!CollectionUtils.isEmpty(certResult.getTestToolsUsed())) {
+            certResult.getTestToolsUsed().stream()
+                .forEach(crtt -> setEmptyStringFieldsToNull(crtt));
+        }
         populateTestToolIds(certResult.getTestToolsUsed());
+    }
+
+    private void setEmptyStringFieldsToNull(CertificationResultTestTool crtt) {
+        if (StringUtils.isEmpty(crtt.getVersion())) {
+            crtt.setVersion(null);
+        }
     }
 
     private void populateTestToolIds(List<CertificationResultTestTool> testTools) {

--- a/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/UcdProcessNormalizer.java
+++ b/chpl/chpl-service/src/main/java/gov/healthit/chpl/upload/listing/normalizer/UcdProcessNormalizer.java
@@ -37,7 +37,10 @@ public class UcdProcessNormalizer {
         if (listing.getSed() != null && !CollectionUtils.isEmpty(listing.getSed().getUcdProcesses())) {
             clearDataForUnattestedCriteria(listing);
             listing.getSed().getUcdProcesses().stream()
-                .forEach(ucdProcess -> populateUcdProcessId(ucdProcess));
+                .forEach(ucdProcess -> {
+                    setEmptyStringFieldsToNull(ucdProcess);
+                    populateUcdProcessId(ucdProcess);
+                });
             findFuzzyMatchesForUnknownUcdProcesses(listing);
 
             List<CertifiedProductUcdProcess> ucdProcessesToRemove = getHopelessUcdProcesses(listing.getSed().getUcdProcesses());
@@ -79,6 +82,12 @@ public class UcdProcessNormalizer {
                     && StringUtils.isBlank(cpUcd.getDetails())
                     && StringUtils.isBlank(cpUcd.getUserEnteredName()))
                 .toList();
+    }
+
+    private void setEmptyStringFieldsToNull(CertifiedProductUcdProcess crup) {
+        if (StringUtils.isEmpty(crup.getDetails())) {
+            crup.setDetails(null);
+        }
     }
 
     private void populateUcdProcessId(CertifiedProductUcdProcess ucdProcess) {


### PR DESCRIPTION
Many of the standards that were valid as of certification date are no longer applicable. They should not be added to any listing.

[#OCD-4793]