### PR TITLE
build(deps): bump org.apache.tomcat:tomcat-catalina

### DIFF
--- a/chpl/chpl-service/pom.xml
+++ b/chpl/chpl-service/pom.xml
@@ -379,7 +379,7 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
-            <version>10.1.35</version>
+            <version>10.1.40</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Bumps org.apache.tomcat:tomcat-catalina from 10.1.35 to 10.1.40.

---
updated-dependencies:
- dependency-name: org.apache.tomcat:tomcat-catalina dependency-version: 10.1.40 dependency-type: direct:production ...