### PR TITLE
build(deps): bump org.apache.logging.log4j:log4j-core in /chpl

### DIFF
--- a/chpl/pom.xml
+++ b/chpl/pom.xml
@@ -23,7 +23,7 @@
         <ff4j.version>2.0.0</ff4j.version>
         <java.version>17</java.version>
         <junit.version>5.9.3</junit.version>
-        <log4j2.version>2.24.3</log4j2.version>
+        <log4j2.version>2.25.3</log4j2.version>
         <lombok.version>1.18.36</lombok.version>
         <mvn.compiler.plugin.version>3.9.0</mvn.compiler.plugin.version>
         <mvn.jar.plugin.version>3.2.1</mvn.jar.plugin.version>


### PR DESCRIPTION
Bumps org.apache.logging.log4j:log4j-core from 2.24.3 to 2.25.3.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core dependency-version: 2.25.3 dependency-type: direct:production ...